### PR TITLE
chore(deps): fix safe Dependabot alerts (patched dev/build deps)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -165,20 +165,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -217,9 +216,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -837,24 +836,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.53",
+            "version": "10.5.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "32768472ebfb6969e6c7399f1c7b09009723f653"
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/32768472ebfb6969e6c7399f1c7b09009723f653",
-                "reference": "32768472ebfb6969e6c7399f1c7b09009723f653",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -867,10 +866,10 @@
                 "phpunit/php-timer": "^6.0.0",
                 "sebastian/cli-parser": "^2.0.1",
                 "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.3",
+                "sebastian/comparator": "^5.0.5",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.2",
+                "sebastian/exporter": "^5.1.4",
                 "sebastian/global-state": "^6.0.2",
                 "sebastian/object-enumerator": "^5.0.0",
                 "sebastian/recursion-context": "^5.0.1",
@@ -918,31 +917,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.53"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2025-08-20T14:40:06+00:00"
+            "time": "2026-07-06T14:50:35+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1114,16 +1097,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.3",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
                 "shasum": ""
             },
             "require": {
@@ -1179,15 +1162,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-10-18T14:56:07+00:00"
+            "time": "2026-01-24T09:25:16+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1380,16 +1375,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.2",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
@@ -1398,7 +1393,7 @@
                 "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -1446,15 +1441,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T07:17:12+00:00"
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1959,16 +1966,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -1997,7 +2004,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -2005,7 +2012,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2083,5 +2090,5 @@
     "platform-dev": {
         "php": ">=7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/omnisend/package-lock.json
+++ b/omnisend/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "form-data": "4.0.4",
+                "form-data": "4.0.6",
                 "qs": ">=6.14.1"
             },
             "devDependencies": {
@@ -25,20 +25,6 @@
             "peerDependencies": {
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0"
-            }
-        },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -598,32 +584,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-dynamic-import": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-export-namespace-from": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.3"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
@@ -6868,212 +6828,6 @@
                 }
             }
         },
-        "node_modules/@wordpress/scripts/node_modules/@babel/core": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-            "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.25.7",
-                "@babel/generator": "^7.25.7",
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-module-transforms": "^7.25.7",
-                "@babel/helpers": "^7.25.7",
-                "@babel/parser": "^7.25.7",
-                "@babel/template": "^7.25.7",
-                "@babel/traverse": "^7.25.7",
-                "@babel/types": "^7.25.7",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@wordpress/scripts/node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-            "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@wordpress/scripts/node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
-            "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.7",
-                "@babel/helper-module-imports": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/plugin-syntax-jsx": "^7.25.7",
-                "@babel/types": "^7.25.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@wordpress/scripts/node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.7.tgz",
-            "integrity": "sha512-Y9p487tyTzB0yDYQOtWnC+9HGOuogtP3/wNpun1xJXEEvI6vip59BSBTsHnekZLqxmPcgsrAKt46HAAb//xGhg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.6",
-                "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@wordpress/scripts/node_modules/@babel/preset-env": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.7.tgz",
-            "integrity": "sha512-Gibz4OUdyNqqLj+7OAvBZxOD7CklCtMA5/j0JgUEwOnaRULsPDXmic2iKxL2DX2vQduPR5wH2hjZas/Vr/Oc0g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.25.7",
-                "@babel/helper-compilation-targets": "^7.25.7",
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-validator-option": "^7.25.7",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.7",
-                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.7",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.7",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.7",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.7",
-                "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-                "@babel/plugin-syntax-import-assertions": "^7.25.7",
-                "@babel/plugin-syntax-import-attributes": "^7.25.7",
-                "@babel/plugin-syntax-import-meta": "^7.10.4",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5",
-                "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-                "@babel/plugin-transform-arrow-functions": "^7.25.7",
-                "@babel/plugin-transform-async-generator-functions": "^7.25.7",
-                "@babel/plugin-transform-async-to-generator": "^7.25.7",
-                "@babel/plugin-transform-block-scoped-functions": "^7.25.7",
-                "@babel/plugin-transform-block-scoping": "^7.25.7",
-                "@babel/plugin-transform-class-properties": "^7.25.7",
-                "@babel/plugin-transform-class-static-block": "^7.25.7",
-                "@babel/plugin-transform-classes": "^7.25.7",
-                "@babel/plugin-transform-computed-properties": "^7.25.7",
-                "@babel/plugin-transform-destructuring": "^7.25.7",
-                "@babel/plugin-transform-dotall-regex": "^7.25.7",
-                "@babel/plugin-transform-duplicate-keys": "^7.25.7",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.7",
-                "@babel/plugin-transform-dynamic-import": "^7.25.7",
-                "@babel/plugin-transform-exponentiation-operator": "^7.25.7",
-                "@babel/plugin-transform-export-namespace-from": "^7.25.7",
-                "@babel/plugin-transform-for-of": "^7.25.7",
-                "@babel/plugin-transform-function-name": "^7.25.7",
-                "@babel/plugin-transform-json-strings": "^7.25.7",
-                "@babel/plugin-transform-literals": "^7.25.7",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
-                "@babel/plugin-transform-member-expression-literals": "^7.25.7",
-                "@babel/plugin-transform-modules-amd": "^7.25.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.25.7",
-                "@babel/plugin-transform-modules-systemjs": "^7.25.7",
-                "@babel/plugin-transform-modules-umd": "^7.25.7",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.7",
-                "@babel/plugin-transform-new-target": "^7.25.7",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.7",
-                "@babel/plugin-transform-numeric-separator": "^7.25.7",
-                "@babel/plugin-transform-object-rest-spread": "^7.25.7",
-                "@babel/plugin-transform-object-super": "^7.25.7",
-                "@babel/plugin-transform-optional-catch-binding": "^7.25.7",
-                "@babel/plugin-transform-optional-chaining": "^7.25.7",
-                "@babel/plugin-transform-parameters": "^7.25.7",
-                "@babel/plugin-transform-private-methods": "^7.25.7",
-                "@babel/plugin-transform-private-property-in-object": "^7.25.7",
-                "@babel/plugin-transform-property-literals": "^7.25.7",
-                "@babel/plugin-transform-regenerator": "^7.25.7",
-                "@babel/plugin-transform-reserved-words": "^7.25.7",
-                "@babel/plugin-transform-shorthand-properties": "^7.25.7",
-                "@babel/plugin-transform-spread": "^7.25.7",
-                "@babel/plugin-transform-sticky-regex": "^7.25.7",
-                "@babel/plugin-transform-template-literals": "^7.25.7",
-                "@babel/plugin-transform-typeof-symbol": "^7.25.7",
-                "@babel/plugin-transform-unicode-escapes": "^7.25.7",
-                "@babel/plugin-transform-unicode-property-regex": "^7.25.7",
-                "@babel/plugin-transform-unicode-regex": "^7.25.7",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.25.7",
-                "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.6",
-                "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.38.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@wordpress/scripts/node_modules/@babel/preset-typescript": {
-            "version": "7.25.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.25.7.tgz",
-            "integrity": "sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.7",
-                "@babel/helper-validator-option": "^7.25.7",
-                "@babel/plugin-syntax-jsx": "^7.25.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.25.7",
-                "@babel/plugin-transform-typescript": "^7.25.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
         "node_modules/@wordpress/scripts/node_modules/@es-joy/jsdoccomment": {
             "version": "0.41.0",
             "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
@@ -7090,43 +6844,33 @@
             }
         },
         "node_modules/@wordpress/scripts/node_modules/@wordpress/babel-preset-default": {
-            "version": "8.47.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.47.0.tgz",
-            "integrity": "sha512-PQBdCYkGIF0hPFfWyLJMVZSToh0gWlVyPNRy+h/U2XHIGX83CCWcY8+YB1xutP20KStFBmO9M/CNLfvSa5DKGw==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.51.0.tgz",
+            "integrity": "sha512-blv2dA2gH9XzD71jiX5rI68Xjioais+n4UC8+wSVcGmHzcVuOHta/serOD8nYzQL0+HOv59O29uzXGONKDWzNg==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@babel/core": "7.25.7",
-                "@babel/plugin-syntax-import-attributes": "7.26.0",
-                "@babel/plugin-transform-react-jsx": "7.25.7",
-                "@babel/plugin-transform-runtime": "7.25.7",
-                "@babel/preset-env": "7.25.7",
-                "@babel/preset-typescript": "7.25.7",
-                "@wordpress/browserslist-config": "^6.47.0",
-                "@wordpress/warning": "^3.47.0",
-                "browserslist": "^4.21.10",
+                "@babel/core": "^7.25.7",
+                "@babel/plugin-syntax-import-attributes": "^7.26.0",
+                "@babel/plugin-transform-react-jsx": "^7.25.7",
+                "@babel/plugin-transform-runtime": "^7.25.7",
+                "@babel/preset-env": "^7.25.7",
+                "@babel/preset-typescript": "^7.25.7",
+                "@wordpress/browserslist-config": "^6.51.0",
+                "@wordpress/warning": "^3.51.0",
+                "browserslist": "^4.28.4",
                 "core-js": "^3.31.0",
-                "react": "^19.2.4"
+                "react": "^18.3.1"
             },
             "engines": {
                 "node": ">=18.12.0",
                 "npm": ">=8.19.2"
             }
         },
-        "node_modules/@wordpress/scripts/node_modules/@wordpress/babel-preset-default/node_modules/react": {
-            "version": "19.2.7",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@wordpress/scripts/node_modules/@wordpress/browserslist-config": {
-            "version": "6.47.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.47.0.tgz",
-            "integrity": "sha512-ogoxvjDH6lH369uc1SLZkVWVkM/lFTQ9hkhzgn7egWigycdFydG7T76iUw0CvOkHlcxTJGIVaBXEUq7Y3oRqjQ==",
+            "version": "6.51.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.51.0.tgz",
+            "integrity": "sha512-/siYL1d2O/evfWkXIDuhIVfHHBYE0T8hiD4JD8xm6JGe9Z2zHikveVT/AvJZrIzUBJknEIADyFE+cXimk97GkA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "engines": {
@@ -7298,28 +7042,14 @@
             }
         },
         "node_modules/@wordpress/scripts/node_modules/@wordpress/warning": {
-            "version": "3.47.0",
-            "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.47.0.tgz",
-            "integrity": "sha512-z4jb5zAMY1rFjNUMLaWz9BoHUe8uKfLqgM/20FooynH/AN9nKPBruJmiOOQvT+5m0sIZ8i7roGW2OdpRjtWP2g==",
+            "version": "3.51.0",
+            "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.51.0.tgz",
+            "integrity": "sha512-wWeM6pjAWbMhdNfgCaxi5yhLzomj6/trcIjGPi2Q4kaIuxUula8Ybq0ZPn5lYuc19ICkcGYcAnWNYz/4mYCHdA==",
             "dev": true,
             "license": "GPL-2.0-or-later",
             "engines": {
                 "node": ">=18.12.0",
                 "npm": ">=8.19.2"
-            }
-        },
-        "node_modules/@wordpress/scripts/node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.10.6",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-            "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.2",
-                "core-js-compat": "^3.38.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@wordpress/scripts/node_modules/eslint-visitor-keys": {
@@ -8147,23 +7877,6 @@
                 "proxy-from-env": "^2.1.0"
             }
         },
-        "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/axios/node_modules/proxy-from-env": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -8472,9 +8185,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.33",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
-            "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+            "version": "2.10.43",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8624,9 +8337,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
             "dev": true,
             "funding": [
                 {
@@ -8644,10 +8357,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -8907,9 +8620,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001793",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+            "version": "1.0.30001805",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+            "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
             "dev": true,
             "funding": [
                 {
@@ -10402,9 +10115,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.366",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz",
-            "integrity": "sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==",
+            "version": "1.5.389",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+            "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
             "dev": true,
             "license": "ISC"
         },
@@ -12201,16 +11914,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -13060,9 +12773,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-            "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+            "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13074,7 +12787,7 @@
                 "micromatch": "^4.0.8"
             },
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -16174,9 +15887,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -22273,9 +21986,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-            "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+            "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -22297,7 +22010,7 @@
                 "graceful-fs": "^4.2.6",
                 "http-proxy-middleware": "^2.0.9",
                 "ipaddr.js": "^2.1.0",
-                "launch-editor": "^2.6.1",
+                "launch-editor": "^2.14.1",
                 "open": "^10.0.3",
                 "p-retry": "^6.2.0",
                 "schema-utils": "^4.2.0",

--- a/omnisend/package.json
+++ b/omnisend/package.json
@@ -10,15 +10,16 @@
         "lint:js": "wp-scripts lint-js"
     },
     "dependencies": {
-        "form-data": "4.0.4",
+        "form-data": "4.0.6",
         "qs": ">=6.14.1"
     },
     "overrides": {
         "qs": ">=6.14.1",
+        "@babel/core": ">=7.29.6",
         "node-forge": ">=1.3.2",
-        "webpack-dev-server": ">=5.2.1",
+        "webpack-dev-server": ">=5.2.5",
         "js-yaml": ">=4.1.1",
-        "http-proxy-middleware": ">=2.0.8",
+        "http-proxy-middleware": ">=3.0.7",
         "on-headers": ">=1.1.0",
         "minimatch": ">=3.1.4",
         "serialize-javascript": ">=7.0.5",


### PR DESCRIPTION
## Summary

Resolves the **safe** open Dependabot alerts on `wp-omnisend` — all in dev/build tooling, not runtime plugin code. Every bump is a patch/minor within the same major, so there are no breaking version changes. `npm run build` still compiles and `composer` reports no advisories.

Fixed (7 of 8 alerts):

| Alert | Package | Change | Sev |
|---|---|---|---|
| #126/#127 | `form-data` | `4.0.4` → `4.0.6` (direct dep + lock) | high |
| #125/#129 | `http-proxy-middleware` | → `3.0.7` (override floor raised `>=2.0.8` → `>=3.0.7`) | high/med |
| #130 | `webpack-dev-server` | → `5.2.6` (override floor `>=5.2.1` → `>=5.2.5`) | med |
| #128 | `@babel/core` | deduped to `7.29.7` via new `>=7.29.6` override (a nested `@wordpress/scripts` copy was pinned at `7.25.7`) | low |
| #45 | `phpunit/phpunit` | `10.5.53` → `10.5.64` (`composer.lock`) | high |

`package.json` diff:

```diff
 "dependencies": {
-    "form-data": "4.0.4",
+    "form-data": "4.0.6",
 },
 "overrides": {
+    "@babel/core": ">=7.29.6",
-    "webpack-dev-server": ">=5.2.1",
+    "webpack-dev-server": ">=5.2.5",
-    "http-proxy-middleware": ">=2.0.8",
+    "http-proxy-middleware": ">=3.0.7",
 }
```

**Deliberately not fixed — #123 `markdown-it` (`<=14.1.1`, high):** it is pulled transitively via `@wordpress/scripts@30 → markdownlint-cli → markdownlint → markdown-it@12.3.2`, and its only available fix is `@wordpress/scripts@33` — a breaking major bump. Left as-is per the "no breaking changes" constraint; flagging for a separate, deliberate `@wordpress/scripts` upgrade.

Initiated-by:greta@omnisend.com

Link to Devin session: https://app.devin.ai/sessions/cf01a409592641f68f0ea93a986a12a3
Requested by: @greta-mik