### PR TITLE
chore: WordPress 7.1 compatibility (v1.8.1)

### DIFF
--- a/omnisend/class-omnisend-core-bootstrap.php
+++ b/omnisend/class-omnisend-core-bootstrap.php
@@ -4,7 +4,7 @@
  *
  * Plugin Name: Newsletters, Email Marketing, SMS and Popups by Omnisend
  * Description: Omnisend main plugin that enables integration with Omnisend.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Requires PHP: 7.4
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
@@ -24,7 +24,7 @@ use Omnisend\Internal\Connection;
 
 defined( 'ABSPATH' ) || die( 'no direct access' );
 
-const OMNISEND_CORE_PLUGIN_VERSION = '1.8.0';
+const OMNISEND_CORE_PLUGIN_VERSION = '1.8.1';
 const OMNISEND_CORE_SETTINGS_PAGE  = 'omnisend';
 const OMNISEND_CORE_PLUGIN_NAME    = 'Email Marketing by Omnisend';
 const OMNISEND_MENU_TITLE          = 'Omnisend Email Marketing';

--- a/omnisend/readme.txt
+++ b/omnisend/readme.txt
@@ -3,7 +3,7 @@ Plugin Name: Newsletters, Email Marketing, SMS and Popups by Omnisend
 Contributors: Omnisend
 Tags: email marketing, marketing, newsletter, sms, form
 Requires at least: 4.7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 1.8.0
 License: GPLv3 or later

--- a/omnisend/readme.txt
+++ b/omnisend/readme.txt
@@ -5,7 +5,7 @@ Tags: email marketing, marketing, newsletter, sms, form
 Requires at least: 4.7.0
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 1.8.0
+Stable tag: 1.8.1
 License: GPLv3 or later
 URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -120,6 +120,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.8.1 =
+
+* Tested up to WordPress 7.1
 
 = 1.8.0 =
 


### PR DESCRIPTION
## What?

- Bump `Tested up to: 7.1` in readme.txt
- Requires PHP unchanged at 7.4 — WP 7.1 minimum is still 7.4
- Patch-bump plugin version 1.8.0 → 1.8.1 so wordpress.org picks up the new Tested up to

## Why?

WordPress 7.1 (Field Guide: https://make.wordpress.org/core/2026/08/05/wordpress-7-1-field-guide/). Audit: connection page uses TextControl (40px default is visual-only); no Navigation/Emotion styling of our components.