### PR TITLE
ci: run PHPUnit suite on push and pull_request (PHP 8.1–8.4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php-version }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: PHP Tests
+run-name: PHP Tests 🔀 ${{ github.ref_name }}
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  PHPUnit:
+    name: PHPUnit (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4']
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPUnit
+        run: ./vendor/bin/phpunit tests


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What
Adds a new `PHP Tests` workflow (`.github/workflows/test.yml`) that runs `composer install` and `./vendor/bin/phpunit tests` on every `push` and `pull_request`, in a matrix over PHP 8.1, 8.2, 8.3 and 8.4 (`fail-fast: false`). CI wiring only — no test cases or runtime code changed.

## Why
The repo's CI (`lint.yml`) only ran `composer validate` + PHPCS; the PHPUnit suite was never executed in CI, so no test-based acceptance criterion of the deprecated-API-removal project (#186–#192) was verifiable. This makes the suite run automatically and lets it become merge-blocking.

Notes for reviewers:
- **PHP 7.4/8.0 not in the matrix**: `composer.lock` pins `phpunit/phpunit` 10.5.53, which requires PHP >= 8.1, so `composer install` cannot succeed on 7.4/8.0. Running there would need widening the constraint (e.g. `^9.6 || ^10`) — flagged on the issue as an open question rather than changing dependencies here.
- **Merge-blocking**: `main` has no required status checks (only the org-level review ruleset). A repo admin must add the checks `PHPUnit (PHP 8.1)`, `PHPUnit (PHP 8.2)`, `PHPUnit (PHP 8.3)`, `PHPUnit (PHP 8.4)` as required status checks to make this job merge-blocking.

Fixes #193

Link to Devin session: https://app.devin.ai/sessions/754653dc98e14b0c8292bb436acef8a3
Requested by: @zbignev-omnisend