### PR TITLE
fix: centralize Omnisend API headers and strictly validate connected flag (PR #179 review follow-up)

### DIFF
--- a/omnisend/includes/Internal/V1/class-client.php
+++ b/omnisend/includes/Internal/V1/class-client.php
@@ -21,6 +21,7 @@ use Omnisend\SDK\V1\CreateProductResponse;
 use Omnisend\SDK\V1\GetContactResponse;
 use Omnisend\SDK\V1\GetCategoryResponse;
 use Omnisend\SDK\V1\GetProductResponse;
+use Omnisend\Internal\ApiRequest;
 use Omnisend\Internal\ApiResponse;
 use Omnisend\Internal\ContactFactory;
 use Omnisend\Internal\CategoryFactory;
@@ -55,12 +56,12 @@ class Client implements \Omnisend\SDK\V1\Client {
 	}
 
 	private function get_request_headers(): array {
-		return array(
-			'Content-Type'          => 'application/json',
-			'Authorization'         => 'Omnisend-API-Key ' . $this->api_key,
-			'Omnisend-Version'      => '2026-03-15',
-			'X-INTEGRATION-NAME'    => $this->plugin_name,
-			'X-INTEGRATION-VERSION' => $this->plugin_version,
+		return ApiRequest::headers(
+			$this->api_key,
+			array(
+				'X-INTEGRATION-NAME'    => $this->plugin_name,
+				'X-INTEGRATION-VERSION' => $this->plugin_version,
+			)
 		);
 	}
 

--- a/omnisend/includes/Internal/class-apirequest.php
+++ b/omnisend/includes/Internal/class-apirequest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Omnisend plugin
+ *
+ * @package OmnisendPlugin
+ */
+
+namespace Omnisend\Internal;
+
+defined( 'ABSPATH' ) || die( 'no direct access' );
+
+class ApiRequest {
+
+	const VERSION = '2026-03-15';
+
+	/**
+	 * Builds the headers every Omnisend API request is made with.
+	 *
+	 * @param string $api_key Omnisend brand API key.
+	 * @param array  $extra_headers Headers only some callers send, for example the integration name and version.
+	 */
+	public static function headers( string $api_key, array $extra_headers = array() ): array {
+		return array_merge(
+			array(
+				'Content-Type'     => 'application/json',
+				'Authorization'    => 'Omnisend-API-Key ' . $api_key,
+				'Omnisend-Version' => self::VERSION,
+			),
+			$extra_headers
+		);
+	}
+}

--- a/omnisend/includes/Internal/class-apiresponse.php
+++ b/omnisend/includes/Internal/class-apiresponse.php
@@ -75,6 +75,14 @@ class ApiResponse {
 		return self::error( self::ERROR_UNEXPECTED_SHAPE, "{$expected_field} not found in response." );
 	}
 
+	/**
+	 * @param string $field Field the caller found in the response with an unusable value.
+	 * @param string $detail What is wrong with the value.
+	 */
+	public static function unexpected_value_error( string $field, string $detail ): WP_Error {
+		return self::error( self::ERROR_UNEXPECTED_SHAPE, "{$field} in response {$detail}." );
+	}
+
 	private static function status_error( int $status, string $reason, $data, string $body ): WP_Error {
 		$problem = self::problem_details( $data );
 

--- a/omnisend/includes/Internal/class-connection.php
+++ b/omnisend/includes/Internal/class-connection.php
@@ -68,11 +68,7 @@ class Connection {
 		$response = wp_remote_get(
 			OMNISEND_CORE_API . '/brands/current',
 			array(
-				'headers' => array(
-					'Content-Type'     => 'application/json',
-					'Authorization'    => 'Omnisend-API-Key ' . $api_key,
-					'Omnisend-Version' => '2026-03-15',
-				),
+				'headers' => ApiRequest::headers( $api_key ),
 				'timeout' => 10,
 			)
 		);
@@ -140,11 +136,7 @@ class Connection {
 			OMNISEND_CORE_API . '/accounts',
 			array(
 				'body'    => wp_json_encode( $data ),
-				'headers' => array(
-					'Content-Type'     => 'application/json',
-					'Authorization'    => 'Omnisend-API-Key ' . $api_key,
-					'Omnisend-Version' => '2026-03-15',
-				),
+				'headers' => ApiRequest::headers( $api_key ),
 				'timeout' => 10,
 			)
 		);
@@ -155,8 +147,12 @@ class Connection {
 			return $arr;
 		}
 
-		if ( empty( $arr['connected'] ) ) {
+		if ( ! isset( $arr['connected'] ) || ! is_bool( $arr['connected'] ) ) {
 			return ApiResponse::unexpected_shape_error( 'connected' );
+		}
+
+		if ( $arr['connected'] !== true ) {
+			return ApiResponse::unexpected_value_error( 'connected', 'is false, so the store was not connected' );
 		}
 
 		return true;
@@ -292,6 +288,15 @@ class Connection {
 					array(
 						'success' => false,
 						'error'   => self::get_connection_error_message( ApiResponse::unexpected_shape_error( 'platform' ) ),
+					)
+				);
+			}
+
+			if ( isset( $response['connected'] ) && ! is_bool( $response['connected'] ) ) {
+				return rest_ensure_response(
+					array(
+						'success' => false,
+						'error'   => self::get_connection_error_message( ApiResponse::unexpected_value_error( 'connected', 'is not a boolean' ) ),
 					)
 				);
 			}

--- a/omnisend/includes/SDK/V1/class-getcontactresponse.php
+++ b/omnisend/includes/SDK/V1/class-getcontactresponse.php
@@ -25,7 +25,7 @@ class GetContactResponse {
 		$this->wp_error = $wp_error;
 	}
 
-	public function get_contact(): Contact {
+	public function get_contact(): ?Contact {
 		return $this->contact;
 	}
 

--- a/tests/Omnisend/Internal/ConnectionTest.php
+++ b/tests/Omnisend/Internal/ConnectionTest.php
@@ -156,5 +156,32 @@ final class ConnectionTest extends TestCase
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{}'));
 
         $this->assertStringContainsString('connected not found in response.', $this->connection_error());
+        $this->assertFalse(Options::is_store_connected());
+    }
+
+    public function test_store_connect_with_connected_false_does_not_connect(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"connected":false}'));
+
+        $this->assertStringContainsString('connected in response is false, so the store was not connected.', $this->connection_error());
+        $this->assertFalse(Options::is_store_connected());
+    }
+
+    public function test_store_connect_with_non_boolean_connected_does_not_connect(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"connected":"false"}'));
+
+        $this->assertStringContainsString('connected not found in response.', $this->connection_error());
+        $this->assertFalse(Options::is_store_connected());
+    }
+
+    public function test_non_boolean_connected_in_brand_response_is_rejected(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":"shopify","connected":"true"}'));
+
+        $this->assertStringContainsString('connected in response is not a boolean.', $this->connection_error());
+        $this->assertFalse(Options::is_store_connected());
     }
 }

--- a/tests/Omnisend/Internal/V1/ClientTest.php
+++ b/tests/Omnisend/Internal/V1/ClientTest.php
@@ -35,6 +35,8 @@ final class ClientTest extends TestCase
         $this->assertEquals('https://api.omnisend.com/api/contacts', $request['url']);
         $this->assertEquals('Omnisend-API-Key brandid-secret', $request['args']['headers']['Authorization']);
         $this->assertEquals('2026-03-15', $request['args']['headers']['Omnisend-Version']);
+        $this->assertEquals('test-plugin', $request['args']['headers']['X-INTEGRATION-NAME']);
+        $this->assertEquals('1.0.0', $request['args']['headers']['X-INTEGRATION-VERSION']);
     }
 
     public function test_create_contact_reports_missing_id_as_unexpected_shape(): void
@@ -89,6 +91,7 @@ final class ClientTest extends TestCase
 
         $response = $this->client()->get_contact_by_email('test@example.com');
 
+        $this->assertNull($response->get_contact());
         $error = $response->get_wp_error();
         $this->assertEquals('http_request_failed', $error->get_error_code());
         $this->assertStringContainsString('timeout', $error->get_error_message());

--- a/tests/Omnisend/SDK/V1/CategoryTest.php
+++ b/tests/Omnisend/SDK/V1/CategoryTest.php
@@ -50,6 +50,23 @@ final class CategoryTest extends TestCase
         $this->assertEquals($error_message, $expected_error_message);
     }
 
+    public function test_factory_accepts_title_at_length_limit(): void {
+        $category_data = array('categoryID' => 'C1234', 'title' => str_repeat('a', 255));
+        $category = CategoryFactory::create_category($category_data);
+
+        $this->assertFalse($category->validate()->has_errors());
+    }
+
+    public function test_factory_rejects_title_over_length_limit(): void {
+        $category_data = array('categoryID' => 'C1234', 'title' => str_repeat('a', 256));
+        $category = CategoryFactory::create_category($category_data);
+
+        $this->assertEquals(
+            'Title must be under 255 characters',
+            $category->validate()->get_error_message('title')
+        );
+    }
+
     public function test_factory_raises_validation_error_on_long_category_id(): void {
         $category_data = array(
             'categoryID' => '


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What
Review follow-up on top of #179 (targets its branch, not `main`):

- New `Omnisend\Internal\ApiRequest::headers( $api_key, $extra_headers )` is now the single place that builds `Content-Type`, `Authorization: Omnisend-API-Key …` and `Omnisend-Version`. `Client::get_request_headers()` passes only `X-INTEGRATION-NAME`/`X-INTEGRATION-VERSION` as extras; `Connection::get_account_data()` and `Connection::connect_store()` no longer inline headers. `2026-03-15` now exists in exactly one place (`ApiRequest::VERSION`).
- `connected` is validated strictly instead of via `empty()`:
  - `connect_store()`: absent or non-boolean → `unexpected_shape_error( 'connected' )`; `false` → new `ApiResponse::unexpected_value_error( 'connected', 'is false, so the store was not connected' )`. Only literal `true` connects the store.
  - `omnisend_post_connection()`: a non-boolean `connected` in the `GET /api/brands/current` response is rejected as an unexpected response instead of being treated as truthy (so `"connected": "false"` can no longer gate the flow).
- `GetContactResponse::get_contact()` return type `Contact` → `?Contact`; the property and constructor were already nullable, so an error response returned `null` from a non-nullable method (TypeError on PHP 7.4+).
- Tests: `connected: false` / non-boolean `connected` on both the brand and the store-connect response, category title 255-accepted / 256-rejected boundaries, integration headers on client requests, and `get_contact()` returning `null` on transport failure.

## Why
Addresses the outstanding review feedback on #179 — the connected-state gate accepted any truthy value, auth/version headers were duplicated in three files, and the nullable-contact getter was a latent TypeError.

Still blocked, deliberately unchanged: the SDK account endpoint (`POST /api/accounts/{brandID}` in `Client::connect_store()`) and the semantics of an existing WordPress brand reporting `connected: false` depend on the contract answers requested in #186 and the API-key permission answers in #187. Neither is recorded yet, so nothing was assumed here.

Verified: `./vendor/bin/phpcs -s --ignore=node_modules,build/* omnisend` (clean) and `./vendor/bin/phpunit --bootstrap tests/dependencies/dependencies.php tests/Omnisend` (142 tests, 231 assertions, OK). No JS touched.

Fixes #188


Link to Devin session: https://app.devin.ai/sessions/b2e7d2496bbe435b8fd99a1e11bb1317
Requested by: @zbignev-omnisend