### PR TITLE
fix(connection): keep /wordpress/settings intentionally and harden its response handling

### DIFF
--- a/omnisend/includes/Internal/class-connection.php
+++ b/omnisend/includes/Internal/class-connection.php
@@ -46,18 +46,47 @@ class Connection {
 		require_once __DIR__ . '/../../view/landing-page.html';
 	}
 
+	/**
+	 * Resolve landing page settings from the wordpress-backend Cloudflare Worker.
+	 *
+	 * This endpoint is intentionally retained because it is served by the
+	 * wordpress-backend Cloudflare Worker in the omnisend/wp-omnisend-backend
+	 * repository rather than the versioned Omnisend public API, so it is outside
+	 * the /api migration.
+	 */
 	public static function resolve_wordpress_settings(): void {
 		$url      = 'https://api.omnisend.com/wordpress/settings?version=' . OMNISEND_CORE_PLUGIN_VERSION;
-		$response = wp_remote_get( $url );
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout' => 10,
+			)
+		);
 
-		if ( ! is_wp_error( $response ) ) {
-			$body = wp_remote_retrieve_body( $response );
-
-			$data = json_decode( $body, true );
-			if ( ! empty( $data['exploreOmnisendLink'] ) ) {
-				self::$landing_page_url = $data['exploreOmnisendLink'];
-			}
+		if ( is_wp_error( $response ) ) {
+			return;
 		}
+
+		$http_code = wp_remote_retrieve_response_code( $response );
+		if ( $http_code >= 400 ) {
+			return;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( empty( $body ) ) {
+			return;
+		}
+
+		$data = json_decode( $body, true );
+		if ( ! is_array( $data ) || ! isset( $data['exploreOmnisendLink'] ) || ! is_string( $data['exploreOmnisendLink'] ) || empty( $data['exploreOmnisendLink'] ) ) {
+			return;
+		}
+
+		if ( self::get_naked_domain( $data['exploreOmnisendLink'] ) !== 'omnisend.com' ) {
+			return;
+		}
+
+		self::$landing_page_url = $data['exploreOmnisendLink'];
 	}
 
 	private static function get_account_data( $api_key ): array {

--- a/tests/Omnisend/Internal/ConnectionTest.php
+++ b/tests/Omnisend/Internal/ConnectionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Omnisend\Tests\Unit\Internal;
+
+use Omnisend\Internal\Connection;
+use PHPUnit\Framework\TestCase;
+
+require_once( __DIR__ . '/../../dependencies/dependencies.php' );
+
+if ( ! defined( 'OMNISEND_CORE_PLUGIN_VERSION' ) ) {
+	define( 'OMNISEND_CORE_PLUGIN_VERSION', '1.8.1' );
+}
+
+final class ConnectionTest extends TestCase
+{
+	private $default_landing_page_url = 'https://app.omnisend.com/registrationv2?utm_source=wordpress_plugin&utm_content=landing_page';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		Connection::$landing_page_url = $this->default_landing_page_url;
+		$GLOBALS['omnisend_test_http_response'] = array(
+			'body'     => '',
+			'response' => array(
+				'code' => 200,
+			),
+		);
+	}
+
+	protected function tearDown(): void
+	{
+		Connection::$landing_page_url = $this->default_landing_page_url;
+		unset( $GLOBALS['omnisend_test_http_response'] );
+
+		parent::tearDown();
+	}
+
+	public function test_landing_page_url_is_applied_from_wordpress_settings(): void
+	{
+		$landing_page_url = 'https://app.omnisend.com/registrationv2?utm_source=wordpress_plugin&utm_content=explore';
+		$GLOBALS['omnisend_test_http_response'] = array(
+			'body'     => json_encode(
+				array(
+					'exploreOmnisendLink' => $landing_page_url,
+				)
+			),
+			'response' => array(
+				'code' => 200,
+			),
+		);
+
+		Connection::resolve_wordpress_settings();
+
+		$this->assertSame( $landing_page_url, Connection::$landing_page_url );
+	}
+
+	public function test_wp_error_keeps_default_landing_page_url(): void
+	{
+		$GLOBALS['omnisend_test_http_response'] = new \WP_Error( 'request_failed' );
+
+		Connection::resolve_wordpress_settings();
+
+		$this->assertSame( $this->default_landing_page_url, Connection::$landing_page_url );
+	}
+
+	public function test_http_error_keeps_default_landing_page_url(): void
+	{
+		$GLOBALS['omnisend_test_http_response'] = array(
+			'body'     => '{"exploreOmnisendLink":"https://app.omnisend.com/explore"}',
+			'response' => array(
+				'code' => 500,
+			),
+		);
+
+		Connection::resolve_wordpress_settings();
+
+		$this->assertSame( $this->default_landing_page_url, Connection::$landing_page_url );
+	}
+
+	public function test_empty_body_keeps_default_landing_page_url(): void
+	{
+		$GLOBALS['omnisend_test_http_response']['body'] = '';
+
+		Connection::resolve_wordpress_settings();
+
+		$this->assertSame( $this->default_landing_page_url, Connection::$landing_page_url );
+	}
+
+	public function test_malformed_json_keeps_default_landing_page_url(): void
+	{
+		$GLOBALS['omnisend_test_http_response']['body'] = '{malformed';
+
+		Connection::resolve_wordpress_settings();
+
+		$this->assertSame( $this->default_landing_page_url, Connection::$landing_page_url );
+	}
+
+	public function test_missing_explore_link_keeps_default_landing_page_url(): void
+	{
+		$GLOBALS['omnisend_test_http_response']['body'] = '{"otherSetting":"value"}';
+
+		Connection::resolve_wordpress_settings();
+
+		$this->assertSame( $this->default_landing_page_url, Connection::$landing_page_url );
+	}
+
+	public function test_non_omnisend_domain_keeps_default_landing_page_url(): void
+	{
+		$GLOBALS['omnisend_test_http_response']['body'] = '{"exploreOmnisendLink":"https://example.com/explore"}';
+
+		Connection::resolve_wordpress_settings();
+
+		$this->assertSame( $this->default_landing_page_url, Connection::$landing_page_url );
+	}
+}

--- a/tests/dependencies/dependencies.php
+++ b/tests/dependencies/dependencies.php
@@ -34,6 +34,7 @@ function require_classes($directory) {
 /* START | Fix WordPress requirements */
 require_once(__DIR__ . '/list/class-wp-error.php');
 require_once(__DIR__ . '/list/formatting.php');
+require_once(__DIR__ . '/list/http.php');
 
 function do_action($args) {
     return;

--- a/tests/dependencies/list/http.php
+++ b/tests/dependencies/list/http.php
@@ -1,0 +1,21 @@
+<?php
+
+function wp_remote_get( $url, $args = array() ) {
+	return $GLOBALS['omnisend_test_http_response'] ?? array();
+}
+
+function wp_remote_retrieve_body( $response ) {
+	return $response['body'] ?? '';
+}
+
+function wp_remote_retrieve_response_code( $response ) {
+	return $response['response']['code'] ?? 0;
+}
+
+function is_wp_error( $thing ) {
+	return $thing instanceof WP_Error;
+}
+
+function wp_parse_url( $url, $component = -1 ) {
+	return parse_url( $url, $component );
+}


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What
- `Connection::resolve_wordpress_settings()` keeps calling `GET https://api.omnisend.com/wordpress/settings?version=`, now with a documented reason and a 10s timeout.
- The response is validated before it can replace `Connection::$landing_page_url`: `WP_Error`, HTTP >= 400, empty body, non-array/malformed JSON, missing/empty/non-string `exploreOmnisendLink`, and links whose naked domain isn't `omnisend.com` all leave the hard-coded default in place, so the landing page always renders.
- New `tests/Omnisend/Internal/ConnectionTest.php` (success + 6 failure paths) plus injectable `wp_remote_*` stubs in `tests/dependencies/list/http.php`.

## Why
This path is **not** part of the deprecated `/v3` / `/v5` public API surface and is not routed through `api_gateway` — it is served by the `wordpress-backend` Cloudflare Worker in `omnisend/wp-omnisend-backend` (CODEOWNERS `@omnisend/ecom-platforms`), which also emits the `Wordpress Landing Page Viewed` Mixpanel event and does KV-based variant selection. There is no `/api` replacement, so the owner-scoped decision is to keep the path as-is and harden the client instead. Decision record: https://github.com/omnisend/ecom-platforms-projects/pull/15

Verification: `composer install`, `composer validate --strict`, `./vendor/bin/phpcs -s --ignore=node_modules,build/\* omnisend` (clean), `./vendor/bin/phpunit tests` → OK (93 tests, 111 assertions). No JS touched.

Fixes #191

Link to Devin session: https://app.devin.ai/sessions/06bd320b3cd74aa3ac91ac1963a9a1e2
Requested by: @zbignev-omnisend