### PR TITLE
test: guard the public SDK V1 surface with a baseline regression test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,15 @@ jobs:
 
       - name: Lint PHP files
         run: ./lint.sh check
+
+  Tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHPUnit
+        run: ./vendor/bin/phpunit tests/Omnisend/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ run-name: PHP Standards 🔀 ${{ github.ref_name }}
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   Lint:
     name: Lint

--- a/tests/Omnisend/SDK/SdkSurface.php
+++ b/tests/Omnisend/SDK/SdkSurface.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Reflection-based description of the public SDK surface (omnisend/includes/SDK).
+ *
+ * Used by SdkSurfaceTest to compare the current code against the committed baseline in
+ * sdk-surface-baseline.php, and by tests/tools/dump-sdk-surface.php to regenerate it.
+ */
+
+namespace Omnisend\Tests\SDK;
+
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionType;
+use ReflectionUnionType;
+
+final class SdkSurface
+{
+    public const SDK_DIRECTORY = __DIR__ . '/../../../omnisend/includes/SDK';
+
+    /**
+     * @return array<string, array<string, mixed>> class name => description of its surface
+     */
+    public static function collect(): array
+    {
+        $surface = [];
+
+        foreach (self::sdk_class_names() as $class_name) {
+            $reflection = new ReflectionClass($class_name);
+
+            $surface[$class_name] = [
+                'kind'      => $reflection->isInterface() ? 'interface' : ($reflection->isAbstract() ? 'abstract class' : 'class'),
+                'parent'    => $reflection->getParentClass() === false ? null : $reflection->getParentClass()->getName(),
+                'interfaces' => self::sorted(array_values($reflection->getInterfaceNames())),
+                'constants' => self::constants($reflection),
+                'methods'   => self::methods($reflection),
+            ];
+        }
+
+        ksort($surface);
+
+        return $surface;
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function sdk_class_names(): array
+    {
+        $names = [];
+
+        foreach (self::sdk_files() as $file) {
+            $namespace = self::namespace_of($file);
+            $class     = self::class_name_of($file);
+
+            if ($namespace === null || $class === null) {
+                continue;
+            }
+
+            $names[] = $namespace . '\\' . $class;
+        }
+
+        return self::sorted($names);
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function sdk_files(): array
+    {
+        $files    = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(realpath(self::SDK_DIRECTORY), \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        return self::sorted($files);
+    }
+
+    private static function namespace_of(string $file): ?string
+    {
+        if (preg_match('/^namespace\s+([^;]+);/m', (string) file_get_contents($file), $matches) !== 1) {
+            return null;
+        }
+
+        return trim($matches[1]);
+    }
+
+    private static function class_name_of(string $file): ?string
+    {
+        if (preg_match('/^(?:abstract\s+|final\s+)*(?:class|interface)\s+(\w+)/m', (string) file_get_contents($file), $matches) !== 1) {
+            return null;
+        }
+
+        return $matches[1];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function constants(ReflectionClass $reflection): array
+    {
+        $constants = [];
+
+        foreach ($reflection->getReflectionConstants() as $constant) {
+            if (!$constant->isPublic() || $constant->getDeclaringClass()->getName() !== $reflection->getName()) {
+                continue;
+            }
+
+            $constants[$constant->getName()] = $constant->getValue();
+        }
+
+        ksort($constants);
+
+        return $constants;
+    }
+
+    /**
+     * @return array<string, string> method name => signature
+     */
+    private static function methods(ReflectionClass $reflection): array
+    {
+        $methods = [];
+
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->isPrivate() || $method->getDeclaringClass()->getName() !== $reflection->getName()) {
+                continue;
+            }
+
+            $methods[$method->getName()] = self::signature($method);
+        }
+
+        ksort($methods);
+
+        return $methods;
+    }
+
+    private static function signature(ReflectionMethod $method): string
+    {
+        $parameters = [];
+
+        foreach ($method->getParameters() as $parameter) {
+            $parameters[] = self::parameter($parameter);
+        }
+
+        $visibility = $method->isProtected() ? 'protected' : 'public';
+        $static     = $method->isStatic() ? ' static' : '';
+        $return     = $method->hasReturnType() ? ': ' . self::type($method->getReturnType()) : '';
+
+        return $visibility . $static . ' function ' . $method->getName() . '(' . implode(', ', $parameters) . ')' . $return;
+    }
+
+    private static function parameter(ReflectionParameter $parameter): string
+    {
+        $type = $parameter->hasType() ? self::type($parameter->getType()) . ' ' : '';
+
+        $declaration = $type . ($parameter->isVariadic() ? '...' : '') . '$' . $parameter->getName();
+
+        if (!$parameter->isDefaultValueAvailable()) {
+            return $declaration;
+        }
+
+        return $declaration . ' = ' . self::default_value($parameter);
+    }
+
+    private static function default_value(ReflectionParameter $parameter): string
+    {
+        if ($parameter->isDefaultValueConstant()) {
+            return (string) $parameter->getDefaultValueConstantName();
+        }
+
+        $value = $parameter->getDefaultValue();
+
+        if (is_array($value)) {
+            return $value === [] ? 'array()' : var_export($value, true);
+        }
+
+        return var_export($value, true);
+    }
+
+    private static function type(?ReflectionType $type): string
+    {
+        if ($type instanceof ReflectionNamedType) {
+            return ($type->allowsNull() && $type->getName() !== 'mixed' && $type->getName() !== 'null' ? '?' : '') . $type->getName();
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            $names = [];
+            foreach ($type->getTypes() as $member) {
+                $names[] = self::type($member);
+            }
+
+            return implode('|', $names);
+        }
+
+        return (string) $type;
+    }
+
+    /**
+     * @param string[] $values
+     *
+     * @return string[]
+     */
+    private static function sorted(array $values): array
+    {
+        sort($values);
+
+        return $values;
+    }
+}

--- a/tests/Omnisend/SDK/SdkSurfaceTest.php
+++ b/tests/Omnisend/SDK/SdkSurfaceTest.php
@@ -1,0 +1,86 @@
+<?php
+namespace Omnisend\Tests\SDK;
+
+use Omnisend\SDK\V1\Contact;
+use Omnisend\SDK\V1\GetContactResponse;
+use Omnisend\SDK\V1\Omnisend;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use TypeError;
+use WP_Error;
+
+require_once(__DIR__ . '/../../dependencies/dependencies.php');
+require_once(__DIR__ . '/SdkSurface.php');
+
+/**
+ * Guards the compatibility boundary described in
+ * projects/wp-omnisend-deprecated-api-removal/decisions.md of omnisend/ecom-platforms-projects:
+ * consumer plugins integrate through Omnisend\SDK\V1, so its class names, method names,
+ * signatures, response classes and public constants are a contract.
+ */
+final class SdkSurfaceTest extends TestCase
+{
+    public function test_sdk_surface_matches_the_approved_baseline(): void
+    {
+        foreach (SdkSurface::sdk_class_names() as $class_name) {
+            $this->assertTrue(
+                class_exists($class_name) || interface_exists($class_name),
+                "SDK class {$class_name} could not be loaded"
+            );
+        }
+
+        $baseline = require __DIR__ . '/sdk-surface-baseline.php';
+
+        $this->assertEquals(
+            $baseline,
+            SdkSurface::collect(),
+            'The public SDK surface changed. Consumer plugins integrate through these classes, so '
+            . 'the change has to be an approved deviation: record it in the project decisions file, '
+            . 'then regenerate the baseline with '
+            . '`php tests/tools/dump-sdk-surface.php > tests/Omnisend/SDK/sdk-surface-baseline.php`.'
+        );
+    }
+
+    public function test_internal_client_implements_the_sdk_client_interface(): void
+    {
+        $this->assertTrue(
+            (new ReflectionClass(\Omnisend\Internal\V1\Client::class))->implementsInterface(\Omnisend\SDK\V1\Client::class),
+            'The client returned to consumers must keep implementing Omnisend\SDK\V1\Client.'
+        );
+    }
+
+    public function test_get_client_returns_a_client_implementing_the_sdk_interface(): void
+    {
+        $client = Omnisend::get_client('integration name', '1.0.0');
+
+        $this->assertInstanceOf(\Omnisend\SDK\V1\Client::class, $client);
+    }
+
+    /**
+     * A failed contact lookup reaches the consumer as a TypeError, because the client passes null
+     * while GetContactResponse declares a non-nullable Contact: today at construction, and once the
+     * property becomes nullable, when the contact is read. Consumers must check get_wp_error()
+     * before get_contact(); this is a listed deviation, not a behaviour that may silently change.
+     */
+    public function test_a_failed_contact_lookup_surfaces_as_a_type_error(): void
+    {
+        $this->expectException(TypeError::class);
+
+        $error = new WP_Error();
+        $error->add('omnisend_api', 'HTTP error: 401');
+
+        $response = new GetContactResponse(null, $error);
+        $response->get_contact();
+    }
+
+    public function test_get_contact_response_returns_the_contact_it_was_given(): void
+    {
+        $contact = new Contact();
+        $contact->set_email('test@example.com');
+
+        $response = new GetContactResponse($contact, new WP_Error());
+
+        $this->assertSame($contact, $response->get_contact());
+        $this->assertFalse($response->get_wp_error()->has_errors());
+    }
+}

--- a/tests/Omnisend/SDK/sdk-surface-baseline.php
+++ b/tests/Omnisend/SDK/sdk-surface-baseline.php
@@ -1,0 +1,865 @@
+<?php
+/**
+ * Baseline of the public SDK surface. Regenerate with tests/tools/dump-sdk-surface.php
+ * only when the change to the surface is deliberate and approved.
+ */
+
+return array (
+  'Omnisend\\SDK\\V1\\Batch' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'POST_METHOD' => 'POST',
+      'PUT_METHOD' => 'PUT',
+    ),
+    'methods' => 
+    array (
+      'add_item' => 'public function add_item($item): void',
+      'set_items' => 'public function set_items($items): void',
+      'set_method' => 'public function set_method($method): void',
+      'set_origin' => 'public function set_origin($origin): void',
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Category' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'get_category_id' => 'public function get_category_id(): string',
+      'get_title' => 'public function get_title(): string',
+      'set_category_id' => 'public function set_category_id($category_id): void',
+      'set_title' => 'public function set_title($title): void',
+      'to_array' => 'public function to_array(): array',
+      'to_array_for_update' => 'public function to_array_for_update(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Client' => 
+  array (
+    'kind' => 'interface',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'connect_store' => 'public function connect_store(string $platform): Omnisend\\SDK\\V1\\ConnectStoreResponse',
+      'create_category' => 'public function create_category($category): Omnisend\\SDK\\V1\\CreateCategoryResponse',
+      'create_contact' => 'public function create_contact($contact): Omnisend\\SDK\\V1\\CreateContactResponse',
+      'create_product' => 'public function create_product($product): Omnisend\\SDK\\V1\\CreateProductResponse',
+      'delete_category_by_id' => 'public function delete_category_by_id(string $category_id): Omnisend\\SDK\\V1\\DeleteCategoryResponse',
+      'delete_product_by_id' => 'public function delete_product_by_id(string $product_id): Omnisend\\SDK\\V1\\DeleteProductResponse',
+      'get_category_by_id' => 'public function get_category_by_id(string $category_id): Omnisend\\SDK\\V1\\GetCategoryResponse',
+      'get_contact_by_email' => 'public function get_contact_by_email(string $email): Omnisend\\SDK\\V1\\GetContactResponse',
+      'get_product_by_id' => 'public function get_product_by_id(string $product_id): Omnisend\\SDK\\V1\\GetProductResponse',
+      'replace_product' => 'public function replace_product($product): Omnisend\\SDK\\V1\\CreateProductResponse',
+      'save_contact' => 'public function save_contact(Omnisend\\SDK\\V1\\Contact $contact): Omnisend\\SDK\\V1\\SaveContactResponse',
+      'send_batch' => 'public function send_batch($batch): Omnisend\\SDK\\V1\\SendBatchResponse',
+      'send_customer_event' => 'public function send_customer_event($event): Omnisend\\SDK\\V1\\SendCustomerEventResponse',
+      'update_category' => 'public function update_category($category): Omnisend\\SDK\\V1\\UpdateCategoryResponse',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\ConnectStoreResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error)',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Contact' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'add_custom_property' => 'public function add_custom_property($key, $value, $clean_up_key = true): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'get_address' => 'public function get_address(): string',
+      'get_birthday' => 'public function get_birthday(): string',
+      'get_city' => 'public function get_city(): string',
+      'get_country' => 'public function get_country(): string',
+      'get_custom_properties' => 'public function get_custom_properties(): array',
+      'get_email' => 'public function get_email(): string',
+      'get_email_status' => 'public function get_email_status(): string',
+      'get_first_name' => 'public function get_first_name(): string',
+      'get_gender' => 'public function get_gender(): string',
+      'get_last_name' => 'public function get_last_name(): string',
+      'get_phone' => 'public function get_phone(): string',
+      'get_phone_status' => 'public function get_phone_status(): string',
+      'get_postal_code' => 'public function get_postal_code(): string',
+      'get_state' => 'public function get_state(): string',
+      'get_tags' => 'public function get_tags(): array',
+      'set_address' => 'public function set_address($address): void',
+      'set_birthday' => 'public function set_birthday($birthday): void',
+      'set_city' => 'public function set_city($city): void',
+      'set_country' => 'public function set_country($country): void',
+      'set_email' => 'public function set_email($email): void',
+      'set_email_consent' => 'public function set_email_consent($consent_text): void',
+      'set_email_opt_in' => 'public function set_email_opt_in($opt_in_text): void',
+      'set_email_subscriber' => 'public function set_email_subscriber(): void',
+      'set_email_unsubscriber' => 'public function set_email_unsubscriber(): void',
+      'set_first_name' => 'public function set_first_name($first_name): void',
+      'set_gender' => 'public function set_gender($gender): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_last_name' => 'public function set_last_name($last_name): void',
+      'set_phone' => 'public function set_phone($phone): void',
+      'set_phone_consent' => 'public function set_phone_consent($consent_text): void',
+      'set_phone_opt_in' => 'public function set_phone_opt_in($opt_in_text): void',
+      'set_phone_subscriber' => 'public function set_phone_subscriber(): void',
+      'set_phone_unsubscriber' => 'public function set_phone_unsubscriber(): void',
+      'set_postal_code' => 'public function set_postal_code($postal_code): void',
+      'set_state' => 'public function set_state($state): void',
+      'set_welcome_email' => 'public function set_welcome_email($send_welcome_email): void',
+      'to_array' => 'public function to_array(): array',
+      'to_array_for_event' => 'public function to_array_for_event(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\CreateCategoryResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, string $category_id = \'\')',
+      'get_category_id' => 'public function get_category_id(): string',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\CreateContactResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(string $contact_id, WP_Error $wp_error)',
+      'get_contact_id' => 'public function get_contact_id(): string',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\CreateProductResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, string $product_id = \'\')',
+      'get_product_id' => 'public function get_product_id(): string',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\DeleteCategoryResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, bool $success = false)',
+      'get_response' => 'public function get_response(): bool',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\DeleteProductResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, bool $success = false)',
+      'get_response' => 'public function get_response(): bool',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Event' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'add_custom_event_property' => 'public function add_custom_event_property($key, $value): void',
+      'set_contact' => 'public function set_contact($contact): void',
+      'set_custom_event_name' => 'public function set_custom_event_name($event_name): void',
+      'set_custom_event_properties' => 'public function set_custom_event_properties($properties): void',
+      'set_event_time' => 'public function set_event_time($event_time): void',
+      'set_event_version' => 'public function set_event_version($event_version): void',
+      'set_origin' => 'public function set_origin($origin): void',
+      'set_recommended_event' => 'public function set_recommended_event($event): void',
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\AddedProductToCart' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'EVENT_NAME' => 'added product to cart',
+    ),
+    'methods' => 
+    array (
+      'add_line_item' => 'public function add_line_item($item): void',
+      'set_abandoned_checkout_url' => 'public function set_abandoned_checkout_url($abandoned_checkout_url): void',
+      'set_added_item' => 'public function set_added_item($item): void',
+      'set_cart_id' => 'public function set_cart_id($cart_id): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_value' => 'public function set_value($value): void',
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\Components\\Address' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'set_billing_address_1' => 'public function set_billing_address_1($billing_address_1): void',
+      'set_billing_address_2' => 'public function set_billing_address_2($billing_address_2): void',
+      'set_billing_city' => 'public function set_billing_city($billing_city): void',
+      'set_billing_company' => 'public function set_billing_company($billing_company): void',
+      'set_billing_country' => 'public function set_billing_country($billing_country): void',
+      'set_billing_first_name' => 'public function set_billing_first_name($billing_first_name): void',
+      'set_billing_last_name' => 'public function set_billing_last_name($billing_last_name): void',
+      'set_billing_phone' => 'public function set_billing_phone($billing_phone): void',
+      'set_billing_state' => 'public function set_billing_state($billing_state): void',
+      'set_billing_state_code' => 'public function set_billing_state_code($billing_state_code): void',
+      'set_billing_zip' => 'public function set_billing_zip($billing_zip): void',
+      'set_shipping_address_1' => 'public function set_shipping_address_1($shipping_address_1): void',
+      'set_shipping_address_2' => 'public function set_shipping_address_2($shipping_address_2): void',
+      'set_shipping_city' => 'public function set_shipping_city($shipping_city): void',
+      'set_shipping_company' => 'public function set_shipping_company($shipping_company): void',
+      'set_shipping_country' => 'public function set_shipping_country($shipping_country): void',
+      'set_shipping_first_name' => 'public function set_shipping_first_name($shipping_first_name): void',
+      'set_shipping_last_name' => 'public function set_shipping_last_name($shipping_last_name): void',
+      'set_shipping_phone' => 'public function set_shipping_phone($shipping_phone): void',
+      'set_shipping_state' => 'public function set_shipping_state($shipping_state): void',
+      'set_shipping_state_code' => 'public function set_shipping_state_code($shipping_state_code): void',
+      'set_shipping_zip' => 'public function set_shipping_zip($shipping_zip): void',
+      'to_array_billing' => 'public function to_array_billing(): array',
+      'to_array_shipping' => 'public function to_array_shipping(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\Components\\Discount' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'set_amount' => 'public function set_amount($amount): void',
+      'set_code' => 'public function set_code($code): void',
+      'set_type' => 'public function set_type($type): void',
+      'to_array' => 'public function to_array()',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\Components\\LineItem' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'add_category' => 'public function add_category($product_category): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'set_description' => 'public function set_description($description): void',
+      'set_discount' => 'public function set_discount($discount_amount): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_image_url' => 'public function set_image_url($image_url): void',
+      'set_price' => 'public function set_price($price): void',
+      'set_quantity' => 'public function set_quantity($quantity): void',
+      'set_sku' => 'public function set_sku($sku): void',
+      'set_strike_through_price' => 'public function set_strike_through_price($strike_through_price): void',
+      'set_title' => 'public function set_title($title): void',
+      'set_url' => 'public function set_url($url): void',
+      'set_variant_id' => 'public function set_variant_id($variant_id): void',
+      'set_variant_image_url' => 'public function set_variant_image_url($variant_image_url): void',
+      'set_variant_title' => 'public function set_variant_title($variant_title): void',
+      'set_vendor' => 'public function set_vendor($vendor): void',
+      'set_weight' => 'public function set_weight($weight): void',
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\Components\\ProductCategory' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'set_id' => 'public function set_id($id): void',
+      'set_title' => 'public function set_title($title): void',
+      'to_array' => 'public function to_array()',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\Components\\Tracking' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'set_code' => 'public function set_code($code): void',
+      'set_courier_title' => 'public function set_courier_title($title): void',
+      'set_courier_url' => 'public function set_courier_url($url): void',
+      'to_array' => 'public function to_array()',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\OrderBase' => 
+  array (
+    'kind' => 'abstract class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+      'validate_extra_properties' => 'public function validate_extra_properties(WP_Error $wp_error): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\OrderCanceled' => 
+  array (
+    'kind' => 'class',
+    'parent' => 'Omnisend\\SDK\\V1\\Events\\OrderBase',
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'EVENT_NAME' => 'order canceled',
+    ),
+    'methods' => 
+    array (
+      'add_discount' => 'public function add_discount($discount): void',
+      'add_line_item' => 'public function add_line_item($line_item): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'set_address' => 'public function set_address($address): void',
+      'set_cancel_reason' => 'public function set_cancel_reason($cancel_reason): void',
+      'set_created_at' => 'public function set_created_at($created_at): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_fulfillment_status' => 'public function set_fulfillment_status($fulfillment_status): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_note' => 'public function set_note($note): void',
+      'set_number' => 'public function set_number($number): void',
+      'set_payment_method' => 'public function set_payment_method($payment_method): void',
+      'set_payment_status' => 'public function set_payment_status($payment_status): void',
+      'set_shipping_method' => 'public function set_shipping_method($shipping_method): void',
+      'set_shipping_price' => 'public function set_shipping_price($shipping_price): void',
+      'set_status_url' => 'public function set_status_url($status_url): void',
+      'set_subtotal_price' => 'public function set_subtotal_price($subtotal_price): void',
+      'set_subtotal_tax_included' => 'public function set_subtotal_tax_included($subtotal_tax_included): void',
+      'set_total_discount' => 'public function set_total_discount($total_discount): void',
+      'set_total_price' => 'public function set_total_price($total_price): void',
+      'set_total_tax' => 'public function set_total_tax($total_tax): void',
+      'set_tracking' => 'public function set_tracking($tracking): void',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\OrderFulfilled' => 
+  array (
+    'kind' => 'class',
+    'parent' => 'Omnisend\\SDK\\V1\\Events\\OrderBase',
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'EVENT_NAME' => 'order fulfilled',
+    ),
+    'methods' => 
+    array (
+      'add_discount' => 'public function add_discount($discount): void',
+      'add_line_item' => 'public function add_line_item($line_item): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'set_address' => 'public function set_address($address): void',
+      'set_created_at' => 'public function set_created_at($created_at): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_fulfillment_status' => 'public function set_fulfillment_status($fulfillment_status): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_note' => 'public function set_note($note): void',
+      'set_number' => 'public function set_number($number): void',
+      'set_payment_method' => 'public function set_payment_method($payment_method): void',
+      'set_payment_status' => 'public function set_payment_status($payment_status): void',
+      'set_shipping_method' => 'public function set_shipping_method($shipping_method): void',
+      'set_shipping_price' => 'public function set_shipping_price($shipping_price): void',
+      'set_status_url' => 'public function set_status_url($status_url): void',
+      'set_subtotal_price' => 'public function set_subtotal_price($subtotal_price): void',
+      'set_subtotal_tax_included' => 'public function set_subtotal_tax_included($subtotal_tax_included): void',
+      'set_total_discount' => 'public function set_total_discount($total_discount): void',
+      'set_total_price' => 'public function set_total_price($total_price): void',
+      'set_total_tax' => 'public function set_total_tax($total_tax): void',
+      'set_tracking' => 'public function set_tracking($tracking): void',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\OrderRefunded' => 
+  array (
+    'kind' => 'class',
+    'parent' => 'Omnisend\\SDK\\V1\\Events\\OrderBase',
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'EVENT_NAME' => 'order refunded',
+    ),
+    'methods' => 
+    array (
+      'add_discount' => 'public function add_discount($discount): void',
+      'add_line_item' => 'public function add_line_item($line_item): void',
+      'add_refunded_line_item' => 'public function add_refunded_line_item($refunded_line_item): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'set_address' => 'public function set_address($address): void',
+      'set_created_at' => 'public function set_created_at($created_at): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_fulfillment_status' => 'public function set_fulfillment_status($fulfillment_status): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_note' => 'public function set_note($note): void',
+      'set_number' => 'public function set_number($number): void',
+      'set_payment_method' => 'public function set_payment_method($payment_method): void',
+      'set_payment_status' => 'public function set_payment_status($payment_status): void',
+      'set_shipping_method' => 'public function set_shipping_method($shipping_method): void',
+      'set_shipping_price' => 'public function set_shipping_price($shipping_price): void',
+      'set_status_url' => 'public function set_status_url($status_url): void',
+      'set_subtotal_price' => 'public function set_subtotal_price($subtotal_price): void',
+      'set_subtotal_tax_included' => 'public function set_subtotal_tax_included($subtotal_tax_included): void',
+      'set_total_discount' => 'public function set_total_discount($total_discount): void',
+      'set_total_price' => 'public function set_total_price($total_price): void',
+      'set_total_refunded_amount' => 'public function set_total_refunded_amount($total_refunded_amount): void',
+      'set_total_refunded_tax_amount' => 'public function set_total_refunded_tax_amount($total_refunded_tax_amount): void',
+      'set_total_tax' => 'public function set_total_tax($total_tax): void',
+      'set_tracking' => 'public function set_tracking($tracking): void',
+      'validate_extra_properties' => 'public function validate_extra_properties(WP_Error $error): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\PaidForOrder' => 
+  array (
+    'kind' => 'class',
+    'parent' => 'Omnisend\\SDK\\V1\\Events\\OrderBase',
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'EVENT_NAME' => 'paid for order',
+    ),
+    'methods' => 
+    array (
+      'add_discount' => 'public function add_discount($discount): void',
+      'add_line_item' => 'public function add_line_item($line_item): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'set_address' => 'public function set_address($address): void',
+      'set_created_at' => 'public function set_created_at($created_at): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_fulfillment_status' => 'public function set_fulfillment_status($fulfillment_status): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_note' => 'public function set_note($note): void',
+      'set_number' => 'public function set_number($number): void',
+      'set_payment_method' => 'public function set_payment_method($payment_method): void',
+      'set_payment_status' => 'public function set_payment_status($payment_status): void',
+      'set_shipping_method' => 'public function set_shipping_method($shipping_method): void',
+      'set_shipping_price' => 'public function set_shipping_price($shipping_price): void',
+      'set_status_url' => 'public function set_status_url($status_url): void',
+      'set_subtotal_price' => 'public function set_subtotal_price($subtotal_price): void',
+      'set_subtotal_tax_included' => 'public function set_subtotal_tax_included($subtotal_tax_included): void',
+      'set_total_discount' => 'public function set_total_discount($total_discount): void',
+      'set_total_price' => 'public function set_total_price($total_price): void',
+      'set_total_tax' => 'public function set_total_tax($total_tax): void',
+      'set_tracking' => 'public function set_tracking($tracking): void',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\PlacedOrder' => 
+  array (
+    'kind' => 'class',
+    'parent' => 'Omnisend\\SDK\\V1\\Events\\OrderBase',
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'EVENT_NAME' => 'placed order',
+    ),
+    'methods' => 
+    array (
+      'add_discount' => 'public function add_discount($discount): void',
+      'add_line_item' => 'public function add_line_item($line_item): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'set_address' => 'public function set_address($address): void',
+      'set_created_at' => 'public function set_created_at($created_at): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_fulfillment_status' => 'public function set_fulfillment_status($fulfillment_status): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_note' => 'public function set_note($note): void',
+      'set_number' => 'public function set_number($number): void',
+      'set_payment_method' => 'public function set_payment_method($payment_method): void',
+      'set_payment_status' => 'public function set_payment_status($payment_status): void',
+      'set_shipping_method' => 'public function set_shipping_method($shipping_method): void',
+      'set_shipping_price' => 'public function set_shipping_price($shipping_price): void',
+      'set_status_url' => 'public function set_status_url($status_url): void',
+      'set_subtotal_price' => 'public function set_subtotal_price($subtotal_price): void',
+      'set_subtotal_tax_included' => 'public function set_subtotal_tax_included($subtotal_tax_included): void',
+      'set_total_discount' => 'public function set_total_discount($total_discount): void',
+      'set_total_price' => 'public function set_total_price($total_price): void',
+      'set_total_tax' => 'public function set_total_tax($total_tax): void',
+      'set_tracking' => 'public function set_tracking($tracking): void',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Events\\StartedCheckout' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'EVENT_NAME' => 'started checkout',
+    ),
+    'methods' => 
+    array (
+      'add_line_item' => 'public function add_line_item($item): void',
+      'set_abandoned_checkout_url' => 'public function set_abandoned_checkout_url($abandoned_checkout_url): void',
+      'set_cart_id' => 'public function set_cart_id($cart_id): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_value' => 'public function set_value($value): void',
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\GetCategoryResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, ?Omnisend\\SDK\\V1\\Category $category = NULL)',
+      'get_category' => 'public function get_category(): ?Omnisend\\SDK\\V1\\Category',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\GetContactResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(?Omnisend\\SDK\\V1\\Contact $contact, WP_Error $wp_error)',
+      'get_contact' => 'public function get_contact(): Omnisend\\SDK\\V1\\Contact',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\GetProductResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, ?Omnisend\\SDK\\V1\\Product $product = NULL)',
+      'get_product' => 'public function get_product(): ?Omnisend\\SDK\\V1\\Product',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Omnisend' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'get_client' => 'public static function get_client($plugin, $version, $options = NULL): Omnisend\\Internal\\V1\\Client',
+      'is_connected' => 'public static function is_connected(): bool',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Options' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'get_origin' => 'public function get_origin(): string',
+      'set_origin' => 'public function set_origin($origin): void',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\Product' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+      'AVAILABLE_STATUS' => 
+      array (
+        0 => 'inStock',
+        1 => 'outOfStock',
+        2 => 'notAvailable',
+      ),
+      'STATUS_IN_STOCK' => 'inStock',
+      'STATUS_NOT_AVAILABLE' => 'notAvailable',
+      'STATUS_OUT_OF_STOCK' => 'outOfStock',
+    ),
+    'methods' => 
+    array (
+      'add_category_id' => 'public function add_category_id($category_id): void',
+      'add_image' => 'public function add_image($image_url): void',
+      'add_tag' => 'public function add_tag($tag, $clean_up_tag = true): void',
+      'add_variant' => 'public function add_variant($variant): void',
+      'get_category_ids' => 'public function get_category_ids(): ?array',
+      'get_created_at' => 'public function get_created_at(): ?string',
+      'get_currency' => 'public function get_currency(): ?string',
+      'get_default_image_url' => 'public function get_default_image_url(): ?string',
+      'get_descripton' => 'public function get_descripton(): ?string',
+      'get_id' => 'public function get_id(): ?string',
+      'get_images' => 'public function get_images(): ?array',
+      'get_status' => 'public function get_status(): ?string',
+      'get_tags' => 'public function get_tags(): ?array',
+      'get_title' => 'public function get_title(): ?string',
+      'get_type' => 'public function get_type(): ?string',
+      'get_updated_at' => 'public function get_updated_at(): ?string',
+      'get_url' => 'public function get_url(): ?string',
+      'get_variants' => 'public function get_variants(): ?array',
+      'get_vendor' => 'public function get_vendor(): ?string',
+      'set_created_at' => 'public function set_created_at($created_at): void',
+      'set_currency' => 'public function set_currency($currency): void',
+      'set_default_image_url' => 'public function set_default_image_url($default_image_url): void',
+      'set_description' => 'public function set_description($description): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_status' => 'public function set_status($status): void',
+      'set_title' => 'public function set_title($title): void',
+      'set_type' => 'public function set_type($type): void',
+      'set_updated_at' => 'public function set_updated_at($updated_at): void',
+      'set_url' => 'public function set_url($url): void',
+      'set_vendor' => 'public function set_vendor($vendor): void',
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\ProductVariant' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      'add_image' => 'public function add_image($image_url): void',
+      'set_default_image_url' => 'public function set_default_image_url($default_image_url): void',
+      'set_description' => 'public function set_description($description): void',
+      'set_id' => 'public function set_id($id): void',
+      'set_price' => 'public function set_price($price): void',
+      'set_sku' => 'public function set_sku($sku): void',
+      'set_status' => 'public function set_status($status): void',
+      'set_strike_through_price' => 'public function set_strike_through_price($strike_through_price): void',
+      'set_title' => 'public function set_title($title): void',
+      'set_url' => 'public function set_url($url): void',
+      'to_array' => 'public function to_array(): array',
+      'validate' => 'public function validate(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\SaveContactResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(string $contact_id, WP_Error $wp_error)',
+      'get_contact_id' => 'public function get_contact_id(): string',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\SendBatchResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, string $batch_id = \'\')',
+      'get_batch_id' => 'public function get_batch_id(): string',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\SendCustomerEventResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error)',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+  'Omnisend\\SDK\\V1\\UpdateCategoryResponse' => 
+  array (
+    'kind' => 'class',
+    'parent' => NULL,
+    'interfaces' => 
+    array (
+    ),
+    'constants' => 
+    array (
+    ),
+    'methods' => 
+    array (
+      '__construct' => 'public function __construct(WP_Error $wp_error, string $category_id = \'\')',
+      'get_category_id' => 'public function get_category_id(): string',
+      'get_wp_error' => 'public function get_wp_error(): WP_Error',
+    ),
+  ),
+);

--- a/tests/tools/dump-sdk-surface.php
+++ b/tests/tools/dump-sdk-surface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Regenerates the SDK surface baseline used by tests/Omnisend/SDK/SdkSurfaceTest.php.
+ *
+ * Run it only when a change to the public SDK surface is deliberate and approved:
+ *
+ *   php tests/tools/dump-sdk-surface.php > tests/Omnisend/SDK/sdk-surface-baseline.php
+ */
+
+require_once __DIR__ . '/../dependencies/dependencies.php';
+require_once __DIR__ . '/../Omnisend/SDK/SdkSurface.php';
+
+use Omnisend\Tests\SDK\SdkSurface;
+
+foreach (SdkSurface::sdk_class_names() as $class_name) {
+    class_exists($class_name) || interface_exists($class_name);
+}
+
+echo "<?php\n";
+echo "/**\n";
+echo " * Baseline of the public SDK surface. Regenerate with tests/tools/dump-sdk-surface.php\n";
+echo " * only when the change to the surface is deliberate and approved.\n";
+echo " */\n\n";
+echo 'return ' . var_export(SdkSurface::collect(), true) . ";\n";


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What

Makes the SDK compatibility boundary of the `/api` migration enforceable:

- `tests/Omnisend/SDK/SdkSurface.php` reflects over every class under `omnisend/includes/SDK`
  and produces a stable description of the consumer-visible surface — kind, parent,
  interfaces, public constants, and public/protected method signatures with parameter types,
  order, defaults and return types (35 classes).
- `tests/Omnisend/SDK/sdk-surface-baseline.php` is the committed baseline;
  `SdkSurfaceTest::test_sdk_surface_matches_the_approved_baseline()` fails on any rename,
  signature change, removed constant or removed class, and points at
  `tests/tools/dump-sdk-surface.php` for regeneration once a deviation is approved.
- Behavioural assertions for the parts a reflection diff cannot see: `Omnisend::get_client()`
  returns something implementing `Omnisend\SDK\V1\Client`, `Omnisend\Internal\V1\Client` keeps
  implementing that interface (it is `get_client()`'s declared return type and
  `wp-omnisend-ninja-forms` type-hints it), and a failed contact lookup surfaces to the
  consumer as a `TypeError` because the client passes `null` while `GetContactResponse`
  declares a non-nullable `Contact`.
- Adds a `Tests` job to `.github/workflows/lint.yml` running `./vendor/bin/phpunit tests/Omnisend/`,
  so the surface test is merge-visible. This overlaps #193 ("Run the PHPUnit suite in CI"),
  which may consolidate it.

The boundary itself — what is frozen, what may change, and the approved deviations — is
recorded in `projects/wp-omnisend-deprecated-api-removal/decisions.md`:
https://github.com/omnisend/ecom-platforms-projects/pull/18

## Why

`wp-omnisend` is the PHP SDK the Omnisend add-on plugins (Contact Form 7, Gravity Forms,
Ninja Forms, Formidable Forms, LifterLMS, Paid Memberships Pro, SureCart) integrate through.
They are released independently on wordpress.org, so an SDK signature change breaks live sites
with no coordinated deploy — and the SDK looks like ordinary internal code in review. PR #179
rewrites the internal client for the header-versioned `/api` form and touches two files under
`omnisend/includes/SDK/V1/`, so the migration needs a mechanical guard rather than reviewer
attention.

Verified that this test and baseline pass unchanged on both `main` and PR #179's branch, i.e.
PR #179 makes no source-incompatible SDK change.

Fixes #192


Link to Devin session: https://app.devin.ai/sessions/c78d254a537f40b6a0c5c7f84fbb5e22
Requested by: @zbignev-omnisend