### PR TITLE
fix: name the missing API-key permission per failing onboarding request

### DIFF
--- a/omnisend/includes/Internal/class-connection.php
+++ b/omnisend/includes/Internal/class-connection.php
@@ -82,13 +82,15 @@ class Connection {
 
 	/**
 	 * Maps API failures to messages an administrator can act on.
+	 *
+	 * @param string $required_permission Permission the rejected request needed, when known.
 	 */
-	private static function get_connection_error_message( WP_Error $error ): string {
+	private static function get_connection_error_message( WP_Error $error, string $required_permission = '' ): string {
 		switch ( $error->get_error_code() ) {
 			case ApiResponse::ERROR_UNAUTHORIZED:
 				return 'The API key was rejected by Omnisend. Check if the API key is correct.';
 			case ApiResponse::ERROR_FORBIDDEN:
-				return 'This API key is missing required permissions (brands.read). Create a new API key with store connection permissions.';
+				return self::get_missing_permission_message( $required_permission );
 			case ApiResponse::ERROR_VERSION_RETIRED:
 				return 'This Omnisend plugin version uses a retired Omnisend API version. Please update the plugin.';
 			case ApiResponse::ERROR_RATE_LIMITED:
@@ -105,6 +107,17 @@ class Connection {
 		}
 
 		return 'The connection did not go through. Details: ' . $error->get_error_message();
+	}
+
+	/**
+	 * The API gateway rejects the key before Omnisend sees the request, so the failing request has to name the permission it needed.
+	 *
+	 * @param string $required_permission Permission the rejected request needed, when known.
+	 */
+	private static function get_missing_permission_message( string $required_permission ): string {
+		$permission = $required_permission === '' ? '' : ' (' . $required_permission . ')';
+
+		return 'This API key is missing required permissions' . $permission . '. In Omnisend create a new API key with store connection permissions and paste it here to reconnect.';
 	}
 
 	public static function show_connected_store_view(): bool {
@@ -271,7 +284,7 @@ class Connection {
 				return rest_ensure_response(
 					array(
 						'success' => false,
-						'error'   => self::get_connection_error_message( $response ),
+						'error'   => self::get_connection_error_message( $response, 'brands.read' ),
 					)
 				);
 			}
@@ -318,7 +331,7 @@ class Connection {
 					return rest_ensure_response(
 						array(
 							'success' => false,
-							'error'   => self::get_connection_error_message( $connected ),
+							'error'   => self::get_connection_error_message( $connected, 'accounts.write' ),
 						)
 					);
 				}

--- a/tests/Omnisend/Internal/ConnectionTest.php
+++ b/tests/Omnisend/Internal/ConnectionTest.php
@@ -22,6 +22,7 @@ final class ConnectionTest extends TestCase
     protected function tearDown(): void
     {
         $_POST = array();
+        $_GET = array();
     }
 
     private function connection_error(): string
@@ -47,7 +48,26 @@ final class ConnectionTest extends TestCase
     {
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(403, '{"title":"Forbidden","detail":"Missing brands.read scope."}'));
 
-        $this->assertStringContainsString('missing required permissions (brands.read)', $this->connection_error());
+        $error = $this->connection_error();
+
+        $this->assertStringContainsString('missing required permissions (brands.read)', $error);
+        $this->assertStringContainsString('paste it here to reconnect', $error);
+        $this->assertFalse(Options::is_store_connected());
+    }
+
+    public function test_missing_permissions_leaves_the_connection_form_available_for_another_key(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(403, '{"title":"Forbidden","detail":"Missing brands.read scope."}'));
+
+        $this->connection_error();
+
+        $_GET = array(
+            'action' => 'show_connection_form',
+            '_wpnonce' => 'nonce',
+        );
+
+        $this->assertTrue(Connection::show_connection_view());
+        $this->assertFalse(Connection::show_connected_store_view());
     }
 
     public function test_retired_api_version(): void
@@ -129,9 +149,9 @@ final class ConnectionTest extends TestCase
     public function test_store_connect_failure_reports_api_error(): void
     {
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(403, '{"title":"Forbidden","detail":"Missing brands.write scope."}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(403, '{"title":"Forbidden","detail":"This action requires the \'accounts.write\' permission."}'));
 
-        $this->assertStringContainsString('missing required permissions', $this->connection_error());
+        $this->assertStringContainsString('missing required permissions (accounts.write)', $this->connection_error());
         $this->assertFalse(Options::is_store_connected());
     }
 


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What
`get_connection_error_message()` took no context, so every 403 during connect claimed `brands.read` was missing — including the `POST /api/accounts` step, which the gateway rejects for a missing `accounts.write`. The permission is now passed by the failing request, and the text tells the admin to paste a store-connection key to reconnect:

```php
self::get_connection_error_message( $response, 'brands.read' );    // GET /api/brands/current
self::get_connection_error_message( $connected, 'accounts.write' ); // POST /api/accounts
```

Tests cover both 403 paths plus that the store stays disconnected and the connection form is still reachable for another key.

Stacked on the #179 migration branch, since the 403 mapping only exists there.

## Why
Issue #187: the missing-permission path has to name a permission an admin can act on, and be covered by a test. Naming the wrong permission on the store-connect step sends merchants to recreate a key that would fail again — the gateway requires `accounts.write` there, which no API key can currently carry (recorded in the project decisions file, omnisend/ecom-platforms-projects#14).

Fixes #187


Link to Devin session: https://app.devin.ai/sessions/9ef328a1a36f45129fc7440fd52ca16a
Requested by: @zbignev-omnisend