### PR TITLE
fix: verify and align /api products, product-categories and batches mappings and limits

### DIFF
--- a/omnisend/includes/Internal/class-utils.php
+++ b/omnisend/includes/Internal/class-utils.php
@@ -57,4 +57,32 @@ class Utils {
 
 		return substr( $tag, 0, 128 );
 	}
+
+	/**
+	 * Validate identifier accepted by Omnisend API. It allows only letters, numbers, underscores and dashes.
+	 *
+	 * @param $identifier
+	 *
+	 * @return bool
+	 */
+	public static function is_valid_identifier( $identifier ): bool {
+		return is_string( $identifier ) && preg_match( '/^[a-zA-Z0-9\-_]+$/', $identifier );
+	}
+
+	/**
+	 * Validate date time in the format that Omnisend API accepts.
+	 *
+	 * @param $date_time
+	 *
+	 * @return bool
+	 */
+	public static function is_valid_api_date_time( $date_time ): bool {
+		if ( ! is_string( $date_time ) ) {
+			return false;
+		}
+
+		$parsed = \DateTime::createFromFormat( 'Y-m-d\TH:i:s\Z', $date_time );
+
+		return $parsed !== false && $parsed->format( 'Y-m-d\TH:i:s\Z' ) === $date_time;
+	}
 }

--- a/omnisend/includes/SDK/V1/class-batch.php
+++ b/omnisend/includes/SDK/V1/class-batch.php
@@ -19,6 +19,8 @@ class Batch {
 	public const POST_METHOD = 'POST';
 	public const PUT_METHOD  = 'PUT';
 
+	private const MAX_ITEMS = 100;
+
 	private const REQUIRED_PROPERTIES = array(
 		'items',
 		'method',
@@ -169,15 +171,15 @@ class Batch {
 	private function validate_properties( WP_Error $error ): WP_Error {
 		foreach ( $this as $property_key => $property_value ) {
 			if ( in_array( $property_key, self::REQUIRED_PROPERTIES ) && empty( $property_value ) ) {
-				$error->add( $property, $property_key . ' is a required property.' );
+				$error->add( $property_key, $property_key . ' is a required property.' );
 			}
 
 			if ( $property_value !== null && in_array( $property_key, self::STRING_PROPERTIES ) && ! is_string( $property_value ) ) {
-				$error->add( $property, $property_key . ' must be a string.' );
+				$error->add( $property_key, $property_key . ' must be a string.' );
 			}
 
 			if ( $property_value !== null && in_array( $property_key, self::ARRAY_PROPERTIES ) && ! is_array( $property_value ) ) {
-				$error->add( $property, $property_key . ' must be an array.' );
+				$error->add( $property_key, $property_key . ' must be an array.' );
 			}
 		}
 
@@ -192,6 +194,10 @@ class Batch {
 	 * @return WP_Error $error
 	 */
 	private function validate_items( WP_Error $error ): WP_Error {
+		if ( empty( $this->items ) ) {
+			return $error;
+		}
+
 		$type = get_class( reset( $this->items ) );
 
 		if ( ! array_key_exists( $type, self::ENDPOINT_MAPPINGS ) ) {
@@ -223,8 +229,12 @@ class Batch {
 	 * @return WP_Error $error
 	 */
 	private function validate_values( WP_Error $error ): WP_Error {
-		if ( empty( $this->items ) || count( $this->items ) > 1000 ) {
-			$error->add( 'items', sprintf( 'Items are empty or batch size limit: %s was exceeded', 1000 ) );
+		if ( empty( $this->items ) || count( $this->items ) > self::MAX_ITEMS ) {
+			$error->add( 'items', sprintf( 'Items are empty or batch size limit: %s was exceeded', self::MAX_ITEMS ) );
+		}
+
+		if ( ! in_array( $this->method, self::AVAILABLE_METHODS ) ) {
+			$error->add( 'method', sprintf( 'Method must be one of the following: %s', implode( ',', self::AVAILABLE_METHODS ) ) );
 		}
 
 		return $error;

--- a/omnisend/includes/SDK/V1/class-category.php
+++ b/omnisend/includes/SDK/V1/class-category.php
@@ -87,7 +87,7 @@ class Category {
 		}
 
 		return array(
-			'categoryId' => $this->category_id,
+			'categoryID' => $this->category_id,
 			'title'      => $this->title,
 		);
 	}

--- a/omnisend/includes/SDK/V1/class-product.php
+++ b/omnisend/includes/SDK/V1/class-product.php
@@ -591,16 +591,24 @@ class Product {
 			$error->add( 'id', 'ID must be under 100 characters' );
 		}
 
-		if ( strlen( $this->title ) > 100 ) {
-			$error->add( 'title', 'Title must be under 100 characters' );
+		if ( ! Utils::is_valid_identifier( (string) $this->id ) ) {
+			$error->add( 'id', 'ID must contain only letters, numbers, underscores and dashes' );
+		}
+
+		if ( strlen( $this->title ) > 255 ) {
+			$error->add( 'title', 'Title must be under 255 characters' );
 		}
 
 		if ( ! ctype_upper( $this->currency ) ) {
 			$error->add( 'currency', 'Currency code must be all uppercase' );
 		}
 
-		if ( $this->description !== null && strlen( $this->description ) > 300 ) {
-			$error->add( 'description', 'Description must be under 300 characters' );
+		if ( strlen( $this->currency ) !== 3 ) {
+			$error->add( 'currency', 'Currency code must be 3 characters long' );
+		}
+
+		if ( $this->description !== null && strlen( $this->description ) > 1000 ) {
+			$error->add( 'description', 'Description must be under 1000 characters' );
 		}
 
 		if ( $this->type !== null && strlen( $this->type ) > 100 ) {
@@ -615,8 +623,64 @@ class Product {
 			$error->add( 'default_image_url', 'Default image must contain a valid URL' );
 		}
 
+		if ( ! empty( $this->default_image_url ) && strlen( $this->default_image_url ) > 1000 ) {
+			$error->add( 'default_image_url', 'Default image URL must be under 1000 characters' );
+		}
+
 		if ( ! filter_var( $this->url, FILTER_VALIDATE_URL ) ) {
 			$error->add( 'url', 'Url must contain a valid URL' );
+		}
+
+		if ( strlen( $this->url ) > 1000 ) {
+			$error->add( 'url', 'Url must be under 1000 characters' );
+		}
+
+		if ( count( $this->images ) > 300 ) {
+			$error->add( 'images', 'Images must not exceed 300 items' );
+		}
+
+		foreach ( $this->images as $image ) {
+			if ( ! filter_var( $image, FILTER_VALIDATE_URL ) ) {
+				$error->add( 'images', 'Image "' . $image . '" must contain a valid URL' );
+			}
+
+			if ( strlen( $image ) > 1000 ) {
+				$error->add( 'images', 'Image URL must be under 1000 characters' );
+			}
+		}
+
+		if ( count( $this->category_ids ) > 100 ) {
+			$error->add( 'category_ids', 'Category IDs must not exceed 100 items' );
+		}
+
+		foreach ( $this->category_ids as $category_id ) {
+			if ( strlen( $category_id ) > 200 ) {
+				$error->add( 'category_ids', 'Category ID must be under 200 characters' );
+			}
+
+			if ( ! Utils::is_valid_identifier( (string) $category_id ) ) {
+				$error->add( 'category_ids', 'Category ID "' . $category_id . '" must contain only letters, numbers, underscores and dashes' );
+			}
+		}
+
+		if ( count( $this->tags ) > 100 ) {
+			$error->add( 'tags', 'Tags must not exceed 100 items' );
+		}
+
+		if ( count( $this->variants ) < 1 ) {
+			$error->add( 'variants', 'Product must have at least 1 variant' );
+		}
+
+		if ( count( $this->variants ) > 500 ) {
+			$error->add( 'variants', 'Variants must not exceed 500 items' );
+		}
+
+		if ( $this->created_at !== null && ! Utils::is_valid_api_date_time( $this->created_at ) ) {
+			$error->add( 'created_at', 'created_at must be in Y-m-d\TH:i:s\Z format' );
+		}
+
+		if ( $this->updated_at !== null && ! Utils::is_valid_api_date_time( $this->updated_at ) ) {
+			$error->add( 'updated_at', 'updated_at must be in Y-m-d\TH:i:s\Z format' );
 		}
 
 		return $error;

--- a/omnisend/includes/SDK/V1/class-productvariant.php
+++ b/omnisend/includes/SDK/V1/class-productvariant.php
@@ -7,6 +7,7 @@
 
 namespace Omnisend\SDK\V1;
 
+use Omnisend\Internal\Utils;
 use Omnisend\SDK\V1\Product;
 use WP_Error;
 
@@ -19,6 +20,7 @@ class ProductVariant {
 	private const REQUIRED_PROPERTIES = array(
 		'id',
 		'price',
+		'status',
 		'title',
 		'url',
 	);
@@ -310,26 +312,71 @@ class ProductVariant {
 			$error->add( 'id', 'ID must be under 100 characters' );
 		}
 
-		if ( strlen( $this->title ) > 100 ) {
-			$error->add( 'title', 'Title must be under 100 characters' );
+		if ( ! Utils::is_valid_identifier( (string) $this->id ) ) {
+			$error->add( 'id', 'ID must contain only letters, numbers, underscores and dashes' );
 		}
 
-		if ( $this->description !== null && strlen( $this->description ) > 300 ) {
-			$error->add( 'description', 'Description must be under 300 characters' );
+		if ( strlen( $this->title ) > 255 ) {
+			$error->add( 'title', 'Title must be under 255 characters' );
 		}
 
-		if ( $this->sku !== null && strlen( $this->sku ) > 100 ) {
-			$error->add( 'sku', 'SKU must be under 100 characters' );
+		if ( $this->description !== null && strlen( $this->description ) > 1000 ) {
+			$error->add( 'description', 'Description must be under 1000 characters' );
+		}
+
+		if ( $this->sku !== null && strlen( $this->sku ) > 255 ) {
+			$error->add( 'sku', 'SKU must be under 255 characters' );
+		}
+
+		if ( ! $this->is_valid_price( $this->price ) ) {
+			$error->add( 'price', 'Price must not be negative and must have no more than 2 decimal places' );
+		}
+
+		if ( ! empty( $this->strike_through_price ) && ! $this->is_valid_price( $this->strike_through_price ) ) {
+			$error->add( 'strike_through_price', 'Strike through price must not be negative and must have no more than 2 decimal places' );
 		}
 
 		if ( ! empty( $this->default_image_url ) && ! filter_var( $this->default_image_url, FILTER_VALIDATE_URL ) ) {
 			$error->add( 'default_image_url', 'Default image URL must contain a valid URL' );
 		}
 
+		if ( ! empty( $this->default_image_url ) && strlen( $this->default_image_url ) > 1000 ) {
+			$error->add( 'default_image_url', 'Default image URL must be under 1000 characters' );
+		}
+
 		if ( ! filter_var( $this->url, FILTER_VALIDATE_URL ) ) {
 			$error->add( 'url', 'Url must contain a valid URL' );
 		}
 
+		if ( strlen( $this->url ) > 1000 ) {
+			$error->add( 'url', 'Url must be under 1000 characters' );
+		}
+
+		if ( count( $this->images ) > 300 ) {
+			$error->add( 'images', 'Images must not exceed 300 items' );
+		}
+
+		foreach ( $this->images as $image ) {
+			if ( ! filter_var( $image, FILTER_VALIDATE_URL ) ) {
+				$error->add( 'images', 'Image "' . $image . '" must contain a valid URL' );
+			}
+
+			if ( strlen( $image ) > 1000 ) {
+				$error->add( 'images', 'Image URL must be under 1000 characters' );
+			}
+		}
+
 		return $error;
+	}
+
+	/**
+	 * Checks that price is not negative and fits into 2 decimal places, as Omnisend API requires
+	 *
+	 * @param mixed $price
+	 *
+	 * @return bool
+	 */
+	private function is_valid_price( $price ): bool {
+		return $price >= 0 && (float) $price === round( (float) $price, 2 );
 	}
 }

--- a/tests/Omnisend/Internal/V1/ClientTest.php
+++ b/tests/Omnisend/Internal/V1/ClientTest.php
@@ -2,7 +2,12 @@
 namespace Omnisend\Internal\V1;
 
 use Omnisend\Internal\ApiResponse;
+use Omnisend\Internal\CategoryFactory;
 use Omnisend\Internal\ContactFactory;
+use Omnisend\Internal\ProductFactory;
+use Omnisend\SDK\V1\Batch;
+use Omnisend\SDK\V1\Category;
+use Omnisend\SDK\V1\Product;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
 use WP_Http_Test_Stub;
@@ -171,5 +176,207 @@ final class ClientTest extends TestCase
         $response = $this->client()->delete_product_by_id('product-1');
 
         $this->assertEquals('http_request_failed', $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_create_product_posts_to_products_and_returns_id(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"id":"product-1"}'));
+
+        $response = $this->client()->create_product($this->product());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('product-1', $response->get_product_id());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('POST', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/products', $request['url']);
+    }
+
+    public function test_create_product_reports_missing_id_as_unexpected_shape(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"productID":"product-1"}'));
+
+        $response = $this->client()->create_product($this->product());
+
+        $this->assertEquals(ApiResponse::ERROR_UNEXPECTED_SHAPE, $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_replace_product_puts_to_product_id_and_returns_id(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"id":"product-1"}'));
+
+        $response = $this->client()->replace_product($this->product());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('product-1', $response->get_product_id());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('PUT', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/products/product-1', $request['url']);
+        $this->assertEquals('product-1', json_decode($request['args']['body'], true)['id']);
+    }
+
+    public function test_get_product_by_id_returns_product(): void
+    {
+        WP_Http_Test_Stub::queue(
+            WP_Http_Test_Stub::response(
+                200,
+                '{"id":"product-1","title":"My product","status":"inStock","currency":"USD","url":"https://example.com/p"}'
+            )
+        );
+
+        $response = $this->client()->get_product_by_id('product-1');
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('product-1', $response->get_product()->get_id());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('GET', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/products/product-1', $request['url']);
+    }
+
+    public function test_delete_product_sends_delete_to_product_id(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(204, ''));
+
+        $this->client()->delete_product_by_id('product-1');
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('DELETE', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/products/product-1', $request['url']);
+    }
+
+    public function test_create_category_posts_category_id_field_and_returns_category_id(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"categoryID":"category-1"}'));
+
+        $response = $this->client()->create_category($this->category());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('category-1', $response->get_category_id());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('POST', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/product-categories', $request['url']);
+        $this->assertEquals(
+            array('categoryID' => 'category-1', 'title' => 'Beauty products'),
+            json_decode($request['args']['body'], true)
+        );
+    }
+
+    public function test_create_category_reports_missing_category_id_as_unexpected_shape(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"id":"category-1"}'));
+
+        $response = $this->client()->create_category($this->category());
+
+        $this->assertEquals(ApiResponse::ERROR_UNEXPECTED_SHAPE, $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_update_category_patches_title_only(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"categoryID":"category-1"}'));
+
+        $response = $this->client()->update_category($this->category());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('category-1', $response->get_category_id());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('PATCH', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/product-categories/category-1', $request['url']);
+        $this->assertEquals(array('title' => 'Beauty products'), json_decode($request['args']['body'], true));
+    }
+
+    public function test_get_category_by_id_returns_category(): void
+    {
+        WP_Http_Test_Stub::queue(
+            WP_Http_Test_Stub::response(200, '{"categoryID":"category-1","title":"Beauty products"}')
+        );
+
+        $response = $this->client()->get_category_by_id('category-1');
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('category-1', $response->get_category()->get_category_id());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('GET', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/product-categories/category-1', $request['url']);
+    }
+
+    public function test_delete_category_accepts_empty_success_body(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(204, ''));
+
+        $response = $this->client()->delete_category_by_id('category-1');
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertTrue($response->get_response());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('DELETE', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/product-categories/category-1', $request['url']);
+    }
+
+    public function test_send_batch_posts_to_batches_and_returns_batch_id(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"batchID":"batch-1","totalCount":1}'));
+
+        $response = $this->client()->send_batch($this->batch());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('batch-1', $response->get_batch_id());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('POST', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/batches', $request['url']);
+        $this->assertEquals('categories', json_decode($request['args']['body'], true)['endpoint']);
+    }
+
+    public function test_send_batch_reports_missing_batch_id_as_unexpected_shape(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"totalCount":1}'));
+
+        $response = $this->client()->send_batch($this->batch());
+
+        $this->assertEquals(ApiResponse::ERROR_UNEXPECTED_SHAPE, $response->get_wp_error()->get_error_code());
+    }
+
+    private function product(): Product
+    {
+        return ProductFactory::create_product(
+            array(
+                'currency' => 'USD',
+                'id' => 'product-1',
+                'status' => 'inStock',
+                'title' => 'My product',
+                'url' => 'https://omnisend.com/products/my-product',
+                'variants' => array(
+                    array(
+                        'id' => 'product-1-variant-1',
+                        'price' => 9.99,
+                        'status' => 'inStock',
+                        'title' => 'My variant',
+                        'url' => 'https://omnisend.com/products/my-product',
+                    )
+                )
+            )
+        );
+    }
+
+    private function category(): Category
+    {
+        return CategoryFactory::create_category(
+            array('categoryID' => 'category-1', 'title' => 'Beauty products')
+        );
+    }
+
+    private function batch(): Batch
+    {
+        $batch = new Batch();
+        $batch->set_method(Batch::POST_METHOD);
+        $batch->set_items(array($this->category()));
+
+        return $batch;
     }
 }

--- a/tests/Omnisend/SDK/V1/BatchTest.php
+++ b/tests/Omnisend/SDK/V1/BatchTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Omnisend\SDK\V1;
+
+use Omnisend\Internal\CategoryFactory;
+use PHPUnit\Framework\TestCase;
+
+require_once( __DIR__ . '/../../../dependencies/dependencies.php' );
+
+final class BatchTest extends TestCase
+{
+    public function test_fails_with_undefined_data(): void {
+        $batch = new Batch();
+
+        $expected_result = array(
+            'items' => array('items is a required property.'),
+            'method' => array('method is a required property.')
+        );
+
+        $this->assertEquals($expected_result, $batch->validate()->errors);
+    }
+
+    public function test_100_items_pass_validation(): void {
+        $batch = $this->batch($this->categories(100));
+
+        $this->assertFalse($batch->validate()->has_errors());
+    }
+
+    public function test_101_items_fail_validation(): void {
+        $batch = $this->batch($this->categories(101));
+
+        $this->assertEquals(
+            'Items are empty or batch size limit: 100 was exceeded',
+            $batch->validate()->get_error_message('items')
+        );
+    }
+
+    public function test_unsupported_method_fails_validation(): void {
+        $batch = $this->batch($this->categories(1));
+        $batch->set_method('PATCH');
+
+        $this->assertEquals(
+            'Method must be one of the following: POST,PUT',
+            $batch->validate()->get_error_message('method')
+        );
+    }
+
+    public function test_mixed_items_fail_validation(): void {
+        $items = $this->categories(1);
+        $items[] = new Product();
+
+        $batch = $this->batch($items);
+
+        $this->assertEquals(
+            'Mixed items found, make sure items are of one type: categories,products,contacts,events',
+            $batch->validate()->get_error_message('Items')
+        );
+    }
+
+    public function test_to_array_uses_categories_endpoint(): void {
+        $batch = $this->batch($this->categories(1));
+
+        $expected_result = array(
+            'endpoint' => 'categories',
+            'method' => 'POST',
+            'items' => array(
+                array(
+                    'categoryID' => 'category-0',
+                    'title' => 'Beauty products'
+                )
+            )
+        );
+
+        $this->assertEquals($expected_result, $batch->to_array());
+    }
+
+    public function test_to_array_includes_origin(): void {
+        $batch = $this->batch($this->categories(1));
+        $batch->set_origin('omnisend');
+
+        $this->assertEquals('omnisend', $batch->to_array()['origin']);
+    }
+
+    private function batch(array $items): Batch {
+        $batch = new Batch();
+        $batch->set_method(Batch::POST_METHOD);
+        $batch->set_items($items);
+
+        return $batch;
+    }
+
+    private function categories(int $count): array {
+        $categories = array();
+
+        for ($i = 0; $i < $count; $i++) {
+            $categories[] = CategoryFactory::create_category(
+                array('categoryID' => 'category-' . $i, 'title' => 'Beauty products')
+            );
+        }
+
+        return $categories;
+    }
+}

--- a/tests/Omnisend/SDK/V1/CategoryTest.php
+++ b/tests/Omnisend/SDK/V1/CategoryTest.php
@@ -67,6 +67,57 @@ final class CategoryTest extends TestCase
         $this->assertEquals($error_message, $expected_error_message);
     }
 
+    public function test_title_of_255_characters_passes_validation(): void {
+        $category_data = array(
+            'categoryID' => 'C1234',
+            'title' => str_repeat('a', 255)
+        );
+
+        $category = CategoryFactory::create_category($category_data);
+
+        $this->assertFalse($category->validate()->has_errors());
+    }
+
+    public function test_title_of_256_characters_fails_validation(): void {
+        $category_data = array(
+            'categoryID' => 'C1234',
+            'title' => str_repeat('a', 256)
+        );
+
+        $category = CategoryFactory::create_category($category_data);
+
+        $this->assertEquals('Title must be under 255 characters', $category->validate()->get_error_message('title'));
+    }
+
+    public function test_category_id_of_100_characters_passes_validation(): void {
+        $category_data = array(
+            'categoryID' => str_repeat('c', 100),
+            'title' => 'Beauty products'
+        );
+
+        $category = CategoryFactory::create_category($category_data);
+
+        $this->assertFalse($category->validate()->has_errors());
+    }
+
+    public function test_category_id_of_101_characters_fails_validation(): void {
+        $category_data = array(
+            'categoryID' => str_repeat('c', 101),
+            'title' => 'Beauty products'
+        );
+
+        $category = CategoryFactory::create_category($category_data);
+
+        $this->assertEquals('Category ID must be under 100 characters', $category->validate()->get_error_message('category_id'));
+    }
+
+    public function test_to_array_for_update_contains_only_title(): void {
+        $category_data = array('categoryID' => 'C1234', 'title' => 'Beauty products');
+        $category = CategoryFactory::create_category($category_data);
+
+        $this->assertEquals(array('title' => 'Beauty products'), $category->to_array_for_update());
+    }
+
     public function test_factory_passes_validation(): void {
         $category_data = array('categoryID' => 'C1234', 'title' => 'Beauty products');
         $category = CategoryFactory::create_category($category_data);
@@ -76,7 +127,7 @@ final class CategoryTest extends TestCase
         $category = $category->to_array();
         
         $expected_result = array(
-            'categoryId' => 'C1234',
+            'categoryID' => 'C1234',
             'title' => 'Beauty products'
         );
 

--- a/tests/Omnisend/SDK/V1/ProductTest.php
+++ b/tests/Omnisend/SDK/V1/ProductTest.php
@@ -76,7 +76,7 @@ final class ProductTest extends TestCase
         $product = ProductFactory::create_product($product_data);
 
         $error_message = $product->validate()->get_error_message('title');
-        $expected_error_message = 'Title must be under 100 characters';
+        $expected_error_message = 'Title must be under 255 characters';
 
         $this->assertEquals($error_message, $expected_error_message);
     }
@@ -307,5 +307,239 @@ final class ProductTest extends TestCase
         );
 
         $this->assertEquals($product, $expected_result);
+    }
+
+    public function test_title_of_255_characters_passes_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('title' => str_repeat('a', 255))));
+
+        $this->assertFalse($product->validate()->has_errors());
+    }
+
+    public function test_title_of_256_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('title' => str_repeat('a', 256))));
+
+        $this->assertEquals('Title must be under 255 characters', $product->validate()->get_error_message('title'));
+    }
+
+    public function test_description_of_1000_characters_passes_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('description' => str_repeat('a', 1000))));
+
+        $this->assertFalse($product->validate()->has_errors());
+    }
+
+    public function test_description_of_1001_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('description' => str_repeat('a', 1001))));
+
+        $this->assertEquals('Description must be under 1000 characters', $product->validate()->get_error_message('description'));
+    }
+
+    public function test_id_of_101_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('id' => str_repeat('p', 101))));
+
+        $this->assertEquals('ID must be under 100 characters', $product->validate()->get_error_message('id'));
+    }
+
+    public function test_id_with_unsupported_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('id' => 'product 1')));
+
+        $this->assertEquals(
+            'ID must contain only letters, numbers, underscores and dashes',
+            $product->validate()->get_error_message('id')
+        );
+    }
+
+    public function test_url_of_1001_characters_fails_validation(): void {
+        $url = 'https://omnisend.com/products/' . str_repeat('a', 1000);
+        $product = ProductFactory::create_product($this->product_data(array('url' => $url)));
+
+        $this->assertEquals('Url must be under 1000 characters', $product->validate()->get_error_message('url'));
+    }
+
+    public function test_default_image_url_of_1001_characters_fails_validation(): void {
+        $image_url = 'https://omnisend.com/media/' . str_repeat('a', 1000) . '.png';
+        $product = ProductFactory::create_product($this->product_data(array('defaultImageUrl' => $image_url)));
+
+        $this->assertEquals(
+            'Default image URL must be under 1000 characters',
+            $product->validate()->get_error_message('default_image_url')
+        );
+    }
+
+    public function test_300_images_pass_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('images' => $this->image_urls(300))));
+
+        $this->assertFalse($product->validate()->has_errors());
+    }
+
+    public function test_301_images_fail_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('images' => $this->image_urls(301))));
+
+        $this->assertEquals('Images must not exceed 300 items', $product->validate()->get_error_message('images'));
+    }
+
+    public function test_image_that_is_not_url_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('images' => array('media/product.png'))));
+
+        $this->assertEquals(
+            'Image "media/product.png" must contain a valid URL',
+            $product->validate()->get_error_message('images')
+        );
+    }
+
+    public function test_100_category_ids_pass_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('categoryIDs' => $this->category_ids(100))));
+
+        $this->assertFalse($product->validate()->has_errors());
+    }
+
+    public function test_101_category_ids_fail_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('categoryIDs' => $this->category_ids(101))));
+
+        $this->assertEquals(
+            'Category IDs must not exceed 100 items',
+            $product->validate()->get_error_message('category_ids')
+        );
+    }
+
+    public function test_category_id_of_201_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('categoryIDs' => array(str_repeat('c', 201)))));
+
+        $this->assertEquals(
+            'Category ID must be under 200 characters',
+            $product->validate()->get_error_message('category_ids')
+        );
+    }
+
+    public function test_category_id_with_unsupported_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('categoryIDs' => array('category 1'))));
+
+        $this->assertEquals(
+            'Category ID "category 1" must contain only letters, numbers, underscores and dashes',
+            $product->validate()->get_error_message('category_ids')
+        );
+    }
+
+    public function test_101_tags_fail_validation(): void {
+        $tags = array();
+
+        for ($i = 0; $i < 101; $i++) {
+            $tags[] = 'tag-' . $i;
+        }
+
+        $product = ProductFactory::create_product($this->product_data(array('tags' => $tags)));
+
+        $this->assertEquals('Tags must not exceed 100 items', $product->validate()->get_error_message('tags'));
+    }
+
+    public function test_product_without_variants_fails_validation(): void {
+        $product_data = $this->product_data();
+        unset($product_data['variants']);
+
+        $product = ProductFactory::create_product($product_data);
+
+        $this->assertEquals('Product must have at least 1 variant', $product->validate()->get_error_message('variants'));
+    }
+
+    public function test_500_variants_pass_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('variants' => $this->variants(500))));
+
+        $this->assertFalse($product->validate()->has_errors());
+    }
+
+    public function test_501_variants_fail_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('variants' => $this->variants(501))));
+
+        $this->assertEquals('Variants must not exceed 500 items', $product->validate()->get_error_message('variants'));
+    }
+
+    public function test_type_of_101_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('type' => str_repeat('t', 101))));
+
+        $this->assertEquals('Type must be under 100 characters', $product->validate()->get_error_message('type'));
+    }
+
+    public function test_vendor_of_101_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('vendor' => str_repeat('v', 101))));
+
+        $this->assertEquals('Vendor must be under 100 characters', $product->validate()->get_error_message('vendor'));
+    }
+
+    public function test_currency_that_is_not_three_characters_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('currency' => 'US')));
+
+        $this->assertEquals('Currency code must be 3 characters long', $product->validate()->get_error_message('currency'));
+    }
+
+    public function test_created_at_in_unsupported_format_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('createdAt' => '2022-01-04 08:30:24')));
+
+        $this->assertEquals(
+            'created_at must be in Y-m-d\TH:i:s\Z format',
+            $product->validate()->get_error_message('created_at')
+        );
+    }
+
+    public function test_updated_at_in_unsupported_format_fails_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('updatedAt' => '2022-01-04T08:30:24+02:00')));
+
+        $this->assertEquals(
+            'updated_at must be in Y-m-d\TH:i:s\Z format',
+            $product->validate()->get_error_message('updated_at')
+        );
+    }
+
+    public function test_updated_at_in_api_format_passes_validation(): void {
+        $product = ProductFactory::create_product($this->product_data(array('updatedAt' => '2022-01-04T08:30:24Z')));
+
+        $this->assertFalse($product->validate()->has_errors());
+    }
+
+    private function product_data(array $overrides = array()): array {
+        $product_data = array(
+            'currency' => 'USD',
+            'id' => 'product-1',
+            'status' => 'inStock',
+            'title' => 'My product',
+            'url' => 'https://omnisend.com/products/my-product',
+            'variants' => $this->variants(1),
+        );
+
+        return array_merge($product_data, $overrides);
+    }
+
+    private function variants(int $count): array {
+        $variants = array();
+
+        for ($i = 0; $i < $count; $i++) {
+            $variants[] = array(
+                'id' => 'product-1-variant-' . $i,
+                'price' => 9.99,
+                'status' => 'inStock',
+                'title' => 'My variant',
+                'url' => 'https://omnisend.com/products/my-product',
+            );
+        }
+
+        return $variants;
+    }
+
+    private function image_urls(int $count): array {
+        $images = array();
+
+        for ($i = 0; $i < $count; $i++) {
+            $images[] = 'https://omnisend.com/media/products/product-' . $i . '.png';
+        }
+
+        return $images;
+    }
+
+    private function category_ids(int $count): array {
+        $category_ids = array();
+
+        for ($i = 0; $i < $count; $i++) {
+            $category_ids[] = 'category-' . $i;
+        }
+
+        return $category_ids;
     }
 }

--- a/tests/Omnisend/SDK/V1/ProductVariantTest.php
+++ b/tests/Omnisend/SDK/V1/ProductVariantTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Omnisend\SDK\V1;
+
+use PHPUnit\Framework\TestCase;
+
+require_once( __DIR__ . '/../../../dependencies/dependencies.php' );
+
+final class ProductVariantTest extends TestCase
+{
+    public function test_fails_with_undefined_data(): void {
+        $variant = new ProductVariant();
+
+        $expected_result = array(
+            'id' => array('id is a required property'),
+            'price' => array('price is a required property'),
+            'status' => array('status is a required property'),
+            'title' => array('title is a required property'),
+            'url' => array('url is a required property')
+        );
+
+        $this->assertEquals($expected_result, $variant->validate()->errors);
+    }
+
+    public function test_passes_validation(): void {
+        $this->assertFalse($this->variant()->validate()->has_errors());
+    }
+
+    public function test_id_of_101_characters_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_id(str_repeat('v', 101));
+
+        $this->assertEquals('ID must be under 100 characters', $variant->validate()->get_error_message('id'));
+    }
+
+    public function test_id_with_unsupported_characters_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_id('variant 1');
+
+        $this->assertEquals(
+            'ID must contain only letters, numbers, underscores and dashes',
+            $variant->validate()->get_error_message('id')
+        );
+    }
+
+    public function test_title_of_255_characters_passes_validation(): void {
+        $variant = $this->variant();
+        $variant->set_title(str_repeat('a', 255));
+
+        $this->assertFalse($variant->validate()->has_errors());
+    }
+
+    public function test_title_of_256_characters_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_title(str_repeat('a', 256));
+
+        $this->assertEquals('Title must be under 255 characters', $variant->validate()->get_error_message('title'));
+    }
+
+    public function test_sku_of_255_characters_passes_validation(): void {
+        $variant = $this->variant();
+        $variant->set_sku(str_repeat('s', 255));
+
+        $this->assertFalse($variant->validate()->has_errors());
+    }
+
+    public function test_sku_of_256_characters_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_sku(str_repeat('s', 256));
+
+        $this->assertEquals('SKU must be under 255 characters', $variant->validate()->get_error_message('sku'));
+    }
+
+    public function test_description_of_1000_characters_passes_validation(): void {
+        $variant = $this->variant();
+        $variant->set_description(str_repeat('a', 1000));
+
+        $this->assertFalse($variant->validate()->has_errors());
+    }
+
+    public function test_description_of_1001_characters_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_description(str_repeat('a', 1001));
+
+        $this->assertEquals(
+            'Description must be under 1000 characters',
+            $variant->validate()->get_error_message('description')
+        );
+    }
+
+    public function test_negative_price_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_price(-1);
+
+        $this->assertEquals(
+            'Price must not be negative and must have no more than 2 decimal places',
+            $variant->validate()->get_error_message('price')
+        );
+    }
+
+    public function test_price_with_three_decimal_places_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_price(9.999);
+
+        $this->assertEquals(
+            'Price must not be negative and must have no more than 2 decimal places',
+            $variant->validate()->get_error_message('price')
+        );
+    }
+
+    public function test_strike_through_price_with_three_decimal_places_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_strike_through_price(19.999);
+
+        $this->assertEquals(
+            'Strike through price must not be negative and must have no more than 2 decimal places',
+            $variant->validate()->get_error_message('strike_through_price')
+        );
+    }
+
+    public function test_url_of_1001_characters_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_url('https://omnisend.com/products/' . str_repeat('a', 1000));
+
+        $this->assertEquals('Url must be under 1000 characters', $variant->validate()->get_error_message('url'));
+    }
+
+    public function test_default_image_url_of_1001_characters_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_default_image_url('https://omnisend.com/media/' . str_repeat('a', 1000) . '.png');
+
+        $this->assertEquals(
+            'Default image URL must be under 1000 characters',
+            $variant->validate()->get_error_message('default_image_url')
+        );
+    }
+
+    public function test_300_images_pass_validation(): void {
+        $variant = $this->variant();
+
+        for ($i = 0; $i < 300; $i++) {
+            $variant->add_image('https://omnisend.com/media/products/product-' . $i . '.png');
+        }
+
+        $this->assertFalse($variant->validate()->has_errors());
+    }
+
+    public function test_301_images_fail_validation(): void {
+        $variant = $this->variant();
+
+        for ($i = 0; $i < 301; $i++) {
+            $variant->add_image('https://omnisend.com/media/products/product-' . $i . '.png');
+        }
+
+        $this->assertEquals('Images must not exceed 300 items', $variant->validate()->get_error_message('images'));
+    }
+
+    public function test_image_that_is_not_url_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->add_image('media/product.png');
+
+        $this->assertEquals(
+            'Image "media/product.png" must contain a valid URL',
+            $variant->validate()->get_error_message('images')
+        );
+    }
+
+    public function test_unsupported_status_fails_validation(): void {
+        $variant = $this->variant();
+        $variant->set_status('in stock');
+
+        $this->assertEquals(
+            'Status must be one of the following: inStock,outOfStock,notAvailable',
+            $variant->validate()->get_error_message('status')
+        );
+    }
+
+    private function variant(): ProductVariant {
+        $variant = new ProductVariant();
+        $variant->set_id('product-1-variant-1');
+        $variant->set_price(9.99);
+        $variant->set_status(Product::STATUS_IN_STOCK);
+        $variant->set_title('My variant');
+        $variant->set_url('https://omnisend.com/products/my-product');
+
+        return $variant;
+    }
+}


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What

Verified every `/api` products, product-categories and batches mapping in the plugin against the serving services' source (`api-gateway` routing, `api_products`, `api_categories`, `api_batches`) and fixed the SDK where it diverged:

- `Category::to_array()` sent `categoryId`; the serving request DTO field is `categoryID`.
- `Batch` allowed 1000 items (serving limit is `min=1,max=100`), validated no `method`, and crashed on empty items (`get_class(reset([]))`); `validate_properties()` also added errors under an undefined `$property` variable instead of `$property_key`.
- `Product` / `ProductVariant` limits were pre-`/api` values (title 100, description 300, SKU 100) and were missing the collection/format limits the serving DTOs enforce.

No changes were needed in `Internal/V1/class-client.php` — every path, method, request/response ID field and status code it uses matches the source. That mapping is now pinned by tests (URL + HTTP method + body + ID field asserted per call), so a regression fails PHPUnit instead of production.

`class-client.php` mapping, all confirmed against source:

| SDK call | Method + path | Success | ID field |
| --- | --- | --- | --- |
| `create_product` | `POST /api/products` | 201 | `id` |
| `replace_product` | `PUT /api/products/{productID}` | 200 | `id` |
| `get_product_by_id` | `GET /api/products/{productID}` | 200 | product body |
| `delete_product_by_id` | `DELETE /api/products/{productID}` | 204 (bodyless, idempotent) | – |
| `create_category` | `POST /api/product-categories` | 201 | `categoryID` |
| `update_category` | `PATCH /api/product-categories/{categoryID}` | 200 | `categoryID` |
| `get_category_by_id` | `GET /api/product-categories/{categoryID}` | 200 | `categoryID` |
| `delete_category_by_id` | `DELETE /api/product-categories/{categoryID}` | 204 (bodyless) | – |
| `send_batch` | `POST /api/batches` | 201 | `batchID` (+ `totalCount`) |

Batch request body is `{method, endpoint, items[, origin]}` with `endpoint` one of `products`, `categories`, `contacts`, `events` and `method` one of `POST`, `PUT`.

Source-backed limits now enforced by the SDK (from `api_products/internal/handler/http/api/productDto/structs.go`, `api_categories/.../v2026-03-15/*`, `api_batches/.../createBatch`):

| Field | Limit |
| --- | --- |
| batch `items` | 1–100 |
| category `categoryID` / `title` | 100 / 255 |
| product `id` | ≤100, `alphanumDashUnderscore` |
| product `title` / `description` | 255 / 1000 |
| product `url`, `defaultImageUrl`, each image | ≤1000 + URL |
| product `images` | ≤300 |
| product `vendor` / `type` | ≤100 |
| product `categoryIDs` | ≤100 entries, each ≤200 + `alphanumDashUnderscore` |
| product `tags` | ≤100 |
| product `variants` | 1–500 |
| product `createdAt` / `updatedAt` | `2006-01-02T15:04:05Z` |
| variant `id` | ≤100, `alphanumDashUnderscore` |
| variant `title` / `sku` / `description` | 255 / 255 / 1000 |
| variant `price`, `strikeThroughPrice` | ≥0, ≤2 decimals (serving `price` validator) |
| variant `url`, `defaultImageUrl`, each image | ≤1000 + URL; `images` ≤300 |
| variant `status` | `oneof=inStock outOfStock notAvailable` (empty fails `oneof`, so it is required) |

Two known approximations, deliberately not made stricter client-side: `currency` is checked as 3 uppercase characters rather than the full `iso4217` code list, and `alphanumDashUnderscore` is implemented as `/^[a-zA-Z0-9\-_]+$/`.

Public SDK method signatures are untouched (#192 owns that boundary) and no contacts/events work is included (#189).

## Why

The migration to the date-versioned `/api` endpoints (#188 / #179) changed field names, status codes and validation limits. Without verification the SDK silently sent payloads the new API rejects — `categoryId` was dropped as unknown, and batches of up to 1000 items would fail server-side validation instead of being caught locally.

Verification (exact commands, on this branch):

- `composer install` — ok
- `./vendor/bin/phpcs -s --ignore=node_modules,build/\* omnisend` (what `./lint.sh check` runs, and phpcs needs an explicit path) — 0 errors
- `./vendor/bin/phpunit tests` — OK (205 tests, 313 assertions)

No JS was touched, so `npm run build` / `npm run lint:js` were not run.

Note on the base branch: this PR targets `devin/1784029533-migrate-omnisend-api-2026-03-15` (#188 / #179), not `main`, because the `/api` client under verification only exists there. It should be retargeted to `main` if #179 lands first.

Fixes #190


Link to Devin session: https://app.devin.ai/sessions/ca5d309313bd4c679f51dd62cedf483c
Requested by: @zbignev-omnisend