### PR TITLE
Verify and fix the /api contacts and events payload/response mappings

### DIFF
--- a/omnisend/includes/Internal/V1/class-client.php
+++ b/omnisend/includes/Internal/V1/class-client.php
@@ -134,12 +134,10 @@ class Client implements \Omnisend\SDK\V1\Client {
 			);
 		}
 
-		$contract_array = $contact->to_array();
-
 		$response = wp_remote_post(
 			OMNISEND_CORE_API . '/contacts',
 			array(
-				'body'    => wp_json_encode( $contract_array ),
+				'body'    => wp_json_encode( $contact->to_array() ),
 				'headers' => array_merge( $this->get_request_headers(), $options ),
 				'timeout' => 10,
 			)
@@ -161,7 +159,7 @@ class Client implements \Omnisend\SDK\V1\Client {
 
 	public function get_contact_by_email( string $email ): GetContactResponse {
 		$error = new WP_Error();
-		$email = str_replace( '+', '%2b', $email );
+		$email = rawurlencode( $email );
 
 		$response = wp_remote_get(
 			OMNISEND_CORE_API . '/contacts?email=' . $email,
@@ -174,6 +172,16 @@ class Client implements \Omnisend\SDK\V1\Client {
 		$contact_data = ApiResponse::parse( $response );
 		if ( is_wp_error( $contact_data ) ) {
 			$error->merge_from( $contact_data );
+			return new GetContactResponse( null, $error );
+		}
+
+		if ( ! isset( $contact_data['contacts'] ) || ! is_array( $contact_data['contacts'] ) ) {
+			$error->merge_from( ApiResponse::unexpected_shape_error( 'Contact list' ) );
+			return new GetContactResponse( null, $error );
+		}
+
+		if ( empty( $contact_data['contacts'] ) ) {
+			$error->merge_from( ApiResponse::not_found_error( 'Contact' ) );
 			return new GetContactResponse( null, $error );
 		}
 

--- a/omnisend/includes/Internal/class-apiresponse.php
+++ b/omnisend/includes/Internal/class-apiresponse.php
@@ -75,6 +75,10 @@ class ApiResponse {
 		return self::error( self::ERROR_UNEXPECTED_SHAPE, "{$expected_field} not found in response." );
 	}
 
+	public static function not_found_error( string $entity ): WP_Error {
+		return self::error( self::ERROR_NOT_FOUND, "{$entity} not found." );
+	}
+
 	private static function status_error( int $status, string $reason, $data, string $body ): WP_Error {
 		$problem = self::problem_details( $data );
 

--- a/omnisend/includes/SDK/V1/class-contact.php
+++ b/omnisend/includes/SDK/V1/class-contact.php
@@ -126,17 +126,17 @@ class Contact {
 
 		$arr = array(
 			'identifiers' => array(),
-			'tags'        => array_values( array_unique( $this->tags ) ),
 		);
 
 		if ( $this->email ) {
 			$email_identifier = array(
-				'type'     => 'email',
-				'id'       => $this->email,
-				'channels' => array(
+				'type'               => 'email',
+				'id'                 => $this->email,
+				'sendWelcomeMessage' => (bool) $this->send_welcome_email,
+				'channels'           => array(
 					'email' => array(
-						'status'     => $this->email_status,
-						'statusDate' => $time_now,
+						'status'          => $this->email_status,
+						'statusChangedAt' => $time_now,
 					),
 				),
 			);
@@ -158,12 +158,13 @@ class Contact {
 
 		if ( $this->phone ) {
 			$phone_identifier = array(
-				'type'     => 'phone',
-				'id'       => $this->phone,
-				'channels' => array(
+				'type'               => 'phone',
+				'id'                 => $this->phone,
+				'sendWelcomeMessage' => (bool) $this->send_welcome_email,
+				'channels'           => array(
 					'sms' => array(
-						'status'     => $this->phone_status,
-						'statusDate' => $time_now,
+						'status'          => $this->phone_status,
+						'statusChangedAt' => $time_now,
 					),
 				),
 			);
@@ -178,8 +179,8 @@ class Contact {
 			$arr['identifiers'][] = $phone_identifier;
 		}
 
-		if ( $this->id ) {
-			$arr['contactID'] = $this->id;
+		if ( $this->tags ) {
+			$arr['tags'] = array_values( array_unique( $this->tags ) );
 		}
 
 		if ( $this->first_name ) {
@@ -216,10 +217,6 @@ class Contact {
 
 		if ( $this->gender ) {
 			$arr['gender'] = $this->gender;
-		}
-
-		if ( $this->send_welcome_email ) {
-			$arr['sendWelcomeEmail'] = $this->send_welcome_email;
 		}
 
 		return $arr;

--- a/tests/Omnisend/Internal/V1/ClientTest.php
+++ b/tests/Omnisend/Internal/V1/ClientTest.php
@@ -3,6 +3,8 @@ namespace Omnisend\Internal\V1;
 
 use Omnisend\Internal\ApiResponse;
 use Omnisend\Internal\ContactFactory;
+use Omnisend\SDK\V1\Contact;
+use Omnisend\SDK\V1\Event;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
 use WP_Http_Test_Stub;
@@ -21,6 +23,46 @@ final class ClientTest extends TestCase
         return new Client('brandid-secret', 'test-plugin', '1.0.0', null);
     }
 
+    private function contact(): Contact
+    {
+        $contact = new Contact();
+        $contact->set_email('test@example.com');
+        $contact->set_phone('+37060000000');
+        $contact->set_welcome_email(true);
+        $contact->add_tag('test-tag');
+
+        return $contact;
+    }
+
+    private function event(): Event
+    {
+        $event = new Event();
+        $event->set_custom_event_name('test-event');
+        $event->set_contact($this->contact());
+
+        return $event;
+    }
+
+    private function assert_common_headers(array $request): void
+    {
+        $this->assertEquals('Omnisend-API-Key brandid-secret', $request['args']['headers']['Authorization']);
+        $this->assertEquals('2026-03-15', $request['args']['headers']['Omnisend-Version']);
+    }
+
+    public static function error_response_provider(): array
+    {
+        return array(
+            array(400, ApiResponse::ERROR_HTTP),
+            array(401, ApiResponse::ERROR_UNAUTHORIZED),
+            array(403, ApiResponse::ERROR_FORBIDDEN),
+            array(404, ApiResponse::ERROR_NOT_FOUND),
+            array(409, ApiResponse::ERROR_CONFLICT),
+            array(410, ApiResponse::ERROR_VERSION_RETIRED),
+            array(429, ApiResponse::ERROR_RATE_LIMITED),
+            array(500, ApiResponse::ERROR_SERVER),
+        );
+    }
+
     public function test_create_contact_sends_versioned_headers_and_returns_id(): void
     {
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"id":"contact-1"}'));
@@ -33,8 +75,7 @@ final class ClientTest extends TestCase
 
         $request = WP_Http_Test_Stub::last_request();
         $this->assertEquals('https://api.omnisend.com/api/contacts', $request['url']);
-        $this->assertEquals('Omnisend-API-Key brandid-secret', $request['args']['headers']['Authorization']);
-        $this->assertEquals('2026-03-15', $request['args']['headers']['Omnisend-Version']);
+        $this->assert_common_headers($request);
     }
 
     public function test_create_contact_reports_missing_id_as_unexpected_shape(): void
@@ -47,6 +88,80 @@ final class ClientTest extends TestCase
         $error = $response->get_wp_error();
         $this->assertEquals(ApiResponse::ERROR_UNEXPECTED_SHAPE, $error->get_error_code());
         $this->assertEquals('Contact id not found in response.', $error->get_error_message());
+    }
+
+    public function test_create_contact_accepts_existing_contact_upsert_response(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"id":"contact-1"}'));
+
+        $response = $this->client()->create_contact($this->contact());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('contact-1', $response->get_contact_id());
+    }
+
+    public function test_create_contact_sends_api_payload(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"id":"contact-1"}'));
+
+        $this->client()->create_contact($this->contact());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $payload = json_decode($request['args']['body'], true);
+        $this->assertArrayNotHasKey('contactID', $payload);
+        $this->assertArrayNotHasKey('sendWelcomeEmail', $payload);
+        $this->assertArrayHasKey('sendWelcomeMessage', $payload['identifiers'][0]);
+        $this->assertTrue($payload['identifiers'][0]['sendWelcomeMessage']);
+        $this->assertTrue($payload['identifiers'][1]['sendWelcomeMessage']);
+        $this->assertArrayHasKey('statusChangedAt', $payload['identifiers'][0]['channels']['email']);
+        $this->assertArrayNotHasKey('statusDate', $payload['identifiers'][0]['channels']['email']);
+        $this->assertEquals(array('test-tag'), $payload['tags']);
+    }
+
+    public function test_create_contact_omits_empty_tags(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"id":"contact-1"}'));
+
+        $contact = new Contact();
+        $contact->set_email('test@example.com');
+        $this->client()->create_contact($contact);
+
+        $payload = json_decode(WP_Http_Test_Stub::last_request()['args']['body'], true);
+        $this->assertArrayNotHasKey('tags', $payload);
+    }
+
+    /**
+     * @dataProvider error_response_provider
+     */
+    public function test_create_contact_reports_api_errors(int $status, string $error_code): void
+    {
+        $body = $status === 429 ? '{"detail":"problem","retryAfter":10}' : '{"detail":"problem"}';
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response($status, $body));
+
+        $response = $this->client()->create_contact($this->contact());
+
+        $this->assertEquals($error_code, $response->get_wp_error()->get_error_code());
+        if ($status === 429) {
+            $this->assertEquals(10, $response->get_wp_error()->get_error_data($error_code)['retryAfter']);
+        }
+    }
+
+    public function test_create_contact_reports_empty_body(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, ''));
+
+        $response = $this->client()->create_contact($this->contact());
+
+        $this->assertEquals(ApiResponse::ERROR_EMPTY_BODY, $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_create_contact_reports_malformed_json(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"id":'));
+
+        $response = $this->client()->create_contact($this->contact());
+
+        $this->assertEquals(ApiResponse::ERROR_INVALID_JSON, $response->get_wp_error()->get_error_code());
     }
 
     public function test_create_contact_preserves_transport_error(): void
@@ -73,6 +188,81 @@ final class ClientTest extends TestCase
         $this->assertStringContainsString('Invalid API key.', $error->get_error_message());
     }
 
+    public function test_create_contact_reports_server_error(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(503, '{"title":"Unavailable"}'));
+
+        $response = $this->client()->create_contact($this->contact());
+
+        $this->assertEquals(ApiResponse::ERROR_SERVER, $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_save_contact_posts_new_contact_and_returns_id(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(201, '{"id":"contact-1"}'));
+
+        $response = $this->client()->save_contact($this->contact());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $this->assertEquals('contact-1', $response->get_contact_id());
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('POST', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/contacts', $request['url']);
+        $this->assert_common_headers($request);
+    }
+
+    /**
+     * @dataProvider error_response_provider
+     */
+    public function test_save_contact_reports_api_errors(int $status, string $error_code): void
+    {
+        $body = $status === 429 ? '{"detail":"problem","retryAfter":10}' : '{"detail":"problem"}';
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response($status, $body));
+
+        $response = $this->client()->save_contact($this->contact());
+
+        $this->assertEquals($error_code, $response->get_wp_error()->get_error_code());
+        if ($status === 429) {
+            $this->assertEquals(10, $response->get_wp_error()->get_error_data($error_code)['retryAfter']);
+        }
+    }
+
+    public function test_save_contact_reports_empty_body(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, ''));
+
+        $response = $this->client()->save_contact($this->contact());
+
+        $this->assertEquals(ApiResponse::ERROR_EMPTY_BODY, $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_save_contact_reports_malformed_json(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"id":'));
+
+        $response = $this->client()->save_contact($this->contact());
+
+        $this->assertEquals(ApiResponse::ERROR_INVALID_JSON, $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_save_contact_preserves_transport_error(): void
+    {
+        WP_Http_Test_Stub::queue(new WP_Error('http_request_failed', 'cURL error 28: timeout'));
+
+        $response = $this->client()->save_contact($this->contact());
+
+        $this->assertEquals('http_request_failed', $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_save_contact_reports_missing_id(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contactID":"contact-1"}'));
+
+        $response = $this->client()->save_contact($this->contact());
+
+        $this->assertEquals(ApiResponse::ERROR_UNEXPECTED_SHAPE, $response->get_wp_error()->get_error_code());
+    }
+
     public function test_get_contact_by_email_returns_contact(): void
     {
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contacts":[{"id":"contact-1","email":"test@example.com"}]}'));
@@ -81,6 +271,48 @@ final class ClientTest extends TestCase
 
         $this->assertFalse($response->get_wp_error()->has_errors());
         $this->assertEquals('test@example.com', $response->get_contact()->get_email());
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('https://api.omnisend.com/api/contacts?email=test%40example.com', $request['url']);
+        $this->assert_common_headers($request);
+    }
+
+    public function test_get_contact_by_email_encodes_email_query(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contacts":[]}'));
+
+        $response = $this->client()->get_contact_by_email('first+tag@example.com');
+
+        $this->assertEquals(ApiResponse::ERROR_NOT_FOUND, $response->get_wp_error()->get_error_code());
+        $this->assertEquals(
+            'https://api.omnisend.com/api/contacts?email=first%2Btag%40example.com',
+            WP_Http_Test_Stub::last_request()['url']
+        );
+    }
+
+    public function test_get_contact_by_email_reports_empty_contacts_as_not_found(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contacts":[],"paging":{}}'));
+
+        $response = $this->client()->get_contact_by_email('test@example.com');
+
+        $this->assertEquals(ApiResponse::ERROR_NOT_FOUND, $response->get_wp_error()->get_error_code());
+        $this->assertEquals('Contact not found.', $response->get_wp_error()->get_error_message());
+    }
+
+    /**
+     * @dataProvider error_response_provider
+     */
+    public function test_get_contact_by_email_reports_api_errors(int $status, string $error_code): void
+    {
+        $body = $status === 429 ? '{"detail":"problem","retryAfter":10}' : '{"detail":"problem"}';
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response($status, $body));
+
+        $response = $this->client()->get_contact_by_email('test@example.com');
+
+        $this->assertEquals($error_code, $response->get_wp_error()->get_error_code());
+        if ($status === 429) {
+            $this->assertEquals(10, $response->get_wp_error()->get_error_data($error_code)['retryAfter']);
+        }
     }
 
     public function test_get_contact_by_email_preserves_transport_error(): void
@@ -134,6 +366,15 @@ final class ClientTest extends TestCase
         $this->assertEquals(ApiResponse::ERROR_EMPTY_BODY, $response->get_wp_error()->get_error_code());
     }
 
+    public function test_get_contact_by_email_reports_unexpected_shape(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contacts":[{}]}'));
+
+        $response = $this->client()->get_contact_by_email('test@example.com');
+
+        $this->assertEquals(ApiResponse::ERROR_UNEXPECTED_SHAPE, $response->get_wp_error()->get_error_code());
+    }
+
     public function test_get_contact_by_email_reports_missing_status(): void
     {
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(0, ''));
@@ -169,6 +410,73 @@ final class ClientTest extends TestCase
         WP_Http_Test_Stub::queue(new WP_Error('http_request_failed', 'cURL error 7: connection refused'));
 
         $response = $this->client()->delete_product_by_id('product-1');
+
+        $this->assertEquals('http_request_failed', $response->get_wp_error()->get_error_code());
+    }
+
+    /**
+     * @dataProvider error_response_provider
+     */
+    public function test_send_customer_event_reports_api_errors(int $status, string $error_code): void
+    {
+        $body = $status === 429 ? '{"detail":"problem","retryAfter":10}' : '{"detail":"problem"}';
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response($status, $body));
+
+        $response = $this->client()->send_customer_event($this->event());
+
+        $this->assertEquals($error_code, $response->get_wp_error()->get_error_code());
+        if ($status === 429) {
+            $this->assertEquals(10, $response->get_wp_error()->get_error_data($error_code)['retryAfter']);
+        }
+    }
+
+    public function test_send_customer_event_accepts_bodyless_202(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(202, ''));
+
+        $response = $this->client()->send_customer_event($this->event());
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('POST', $request['method']);
+        $this->assertEquals('https://api.omnisend.com/api/events', $request['url']);
+        $this->assert_common_headers($request);
+    }
+
+    public function test_send_customer_event_sends_v5_contact_payload(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(202, ''));
+
+        $contact = $this->contact();
+        $contact->set_id('contact-1');
+        $event = new Event();
+        $event->set_custom_event_name('test-event');
+        $event->set_contact($contact);
+
+        $this->client()->send_customer_event($event);
+
+        $payload = json_decode(WP_Http_Test_Stub::last_request()['args']['body'], true);
+        $this->assertEquals('test-event', $payload['eventName']);
+        $this->assertEquals($contact->to_array_for_event(), $payload['contact']);
+        $this->assertEquals('contact-1', $payload['contact']['id']);
+        $this->assertEquals('test@example.com', $payload['contact']['email']);
+        $this->assertEquals('+37060000000', $payload['contact']['phone']);
+    }
+
+    public function test_send_customer_event_reports_malformed_json(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(202, '{"event":'));
+
+        $response = $this->client()->send_customer_event($this->event());
+
+        $this->assertEquals(ApiResponse::ERROR_INVALID_JSON, $response->get_wp_error()->get_error_code());
+    }
+
+    public function test_send_customer_event_preserves_transport_error(): void
+    {
+        WP_Http_Test_Stub::queue(new WP_Error('http_request_failed', 'cURL error 28: timeout'));
+
+        $response = $this->client()->send_customer_event($this->event());
 
         $this->assertEquals('http_request_failed', $response->get_wp_error()->get_error_code());
     }

--- a/tests/Omnisend/SDK/V1/ContactTest.php
+++ b/tests/Omnisend/SDK/V1/ContactTest.php
@@ -49,12 +49,12 @@ final class ContactTest extends TestCase
                     'channels' => [
                         'email' => [
                             'status' => 'nonSubscribed',
-                            'statusDate' => gmdate('c'),
+                            'statusChangedAt' => gmdate('c'),
                         ],
                     ],
+                    'sendWelcomeMessage' => false,
                 ],
             ],
-            'tags' => [],
             'firstName' => 'John',
             'lastName' => 'Doe',
         ];
@@ -240,20 +240,22 @@ final class ContactTest extends TestCase
                 [
                     'type' => 'email',
                     'id' => 'test@example.com',
+                    'sendWelcomeMessage' => false,
                     'channels' => [
                         'email' => [
                             'status' => 'subscribed',
-                            'statusDate' => gmdate('c'),
+                            'statusChangedAt' => gmdate('c'),
                         ],
                     ],
                 ],
                 [
                     'type' => 'phone',
                     'id' => '1234567890',
+                    'sendWelcomeMessage' => false,
                     'channels' => [
                         'sms' => [
                             'status' => 'subscribed',
-                            'statusDate' => gmdate('c'),
+                            'statusChangedAt' => gmdate('c'),
                         ],
                     ],
                 ],


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What

Verified the four contacts/events calls against the serving services' source and fixed the mappings that diverged from the `2026-03-15` `/api` contract:

- `Contact::to_array()` (the POST `/api/contacts` payload): dropped the removed `contactID` and `sendWelcomeEmail` fields, renamed `channels[].statusDate` → `statusChangedAt`, moved welcome-message opt-in to the per-identifier `sendWelcomeMessage` boolean, and stopped always sending `tags` (under the new replace semantics an empty array *cleared* the contact's tags on every save).
- `get_contact_by_email()`: a `200` with an empty `contacts` array is now reported as `ERROR_NOT_FOUND` instead of "unexpected response shape", and the email is properly URL-encoded rather than only escaping `+`.
- Tests: per-call coverage for success, body-less success, request payload/URL/headers, and every documented error class.

`ContactFactory` was verified field-by-field against `ContactResponse` and needed no change beyond the `contactID` → `id` fix already in #179. No public SDK method signature changed (#192), and no products/categories/batches work (#190).

## Why

The `/api` migration (#188 / #179) switched the base path and version header but kept several v5-era payload fields, so contact writes would have been rejected or silently lossy: `statusDate` is not read by the new API (subscription change date lost), `sendWelcomeEmail` is gone (welcome messages default to *on* when the new per-identifier flag is absent), and the always-present `tags` array now wipes existing tags. Empty lookup results were also surfaced as a shape error rather than "not found".

## Source-backed mapping

Verified against `omnisend/api_contacts` (`internal/handler/http/external/preview/*.go`, `contract/requestModel.go`, `contract/responseModel.go`, `API_CHANGELOG.md`), `omnisend/api_public` (`internal/handler/http/api/acceptCustomerEvent/handler.go`, `internal/di/container.go`, `internal/handler/http/middleware/version.go`) and `omnisend/api_gateway` (`config/routing/contacts.yaml`, `config/routing/events.yaml`).

| call | route + status | body returned? | request contract | id field |
|---|---|---|---|---|
| `create_contact` | `POST /api/contacts`, `201` new / `200` existing (upsert by email identifier), scope `contacts.write` | yes, `ContactResponse` JSON | `identifiers[].{id,type,source,channels{<ch>:{status,statusChangedAt}},sendWelcomeMessage,consent}`, `tags`, `customProperties`, name/address/gender/birthdate, `createdAt`, `trackingConsents` | response `id` |
| `save_contact` | same POST (upsert by email) | yes, `ContactResponse` JSON | as above | response `id` |
| `get_contact_by_email` | `GET /api/contacts?email=`, always `200`, scope `contacts.read` | yes, `{"contacts":[…],"paging":{…}}`; no match = empty array, **not** `404` | query filter | `contacts[0].id` |
| `send_customer_event` | `POST /api/events`, `202`, scope `events.write` | **no body** | `eventID`, `eventName`, `eventVersion`, `eventTime`, `origin`, `contact`, `properties` — unchanged from `/v5/events`; contact uses `id` | n/a |

Removed from the contact request as of `2026-03-15` (`API_CHANGELOG.md`): `contactID` (POST no longer updates by id — `PATCH /api/contacts/{id}` does), the legacy top-level `email`/`phone`/`phoneNumber`/`status`/`statusDate`/`optInDate`/`optInIP`/`creationDate`/`source`, and `sendWelcomeEmail`. `channels[].statusDate` became `statusChangedAt`; `tags` now replaces the whole array.

Version header: `middleware.Version()` with `SupportedVersions: ["2026-03-15"]`, `PreviewVersion: "2026-preview"` — missing/invalid → `400`, older → `410`. Errors are RFC 9457 problems.

**Events parity:** in `api_public`'s `internal/di/container.go` both the `/v5/events` and `/api/events` handlers are built over the same `c.UseCases.AcceptCustomerEvent` use case (the `/api` one only wraps it in an event-version metrics decorator) and map into the same `acceptCustomerEvent.Params`, including `compatibility: no-origin`. Downstream segment and automation processing is therefore identical; the only difference is the route metric label.

## Verification

- `composer install` — ok
- `./vendor/bin/phpcs -s --ignore=node_modules,build/\* omnisend` — 0 errors (the bare `./vendor/bin/phpcs` needs a path argument)
- `./vendor/bin/phpunit tests` — 187 tests, 296 assertions, all passing
- No JS touched, so the `omnisend/` npm build/lint were not run.

## Notes

- Based on `devin/1784029533-migrate-omnisend-api-2026-03-15` (#179), not `main`, so this diff contains only the #189 changes; merge after #179.
- Follow-up, not done here: updating a contact by a *known contact id* now requires `PATCH /api/contacts/{id}`, which the internal client cannot do because `Contact` exposes no id accessor — adding one belongs to the SDK boundary work in #192. No plugin code sets a contact id today, so `save_contact()` keeps the upsert-by-email POST.
- Follow-up, not done here: `api_gateway` does not list `Omnisend-Version` in the CORS `allow_headers` for `/api/contacts` and `/api/events` (`/api/events/query` does). Server-to-server callers like this plugin are unaffected; browser callers would be blocked from sending the required header.

Fixes #189


Link to Devin session: https://app.devin.ai/sessions/33e01c4c53ed4e229689d4cf7b6d5df3
Requested by: @zbignev-omnisend