### PR TITLE
feat: OAuth for new connections and reconnects, retained /v3 account write for existing API key installs

### DIFF
--- a/omnisend/class-omnisend-core-bootstrap.php
+++ b/omnisend/class-omnisend-core-bootstrap.php
@@ -34,8 +34,12 @@ const OMNISEND_CORE_CRON_SCHEDULE_EVERY_MINUTE = 'omni_send_core_every_minute';
 const OMNISEND_CORE_CRON_SYNC_CONTACT = 'omni_send_cron_sync_contacts';
 
 // Change for different environment.
-const OMNISEND_CORE_API         = 'https://api.omnisend.com/api';
-const OMNISEND_CORE_SNIPPET_URL = 'https://omnisnippet1.com/inshop/launcher-v2.js';
+const OMNISEND_CORE_API          = 'https://api.omnisend.com/api';
+const OMNISEND_CORE_OAUTH_ISSUER = 'https://app.omnisend.com';
+const OMNISEND_CORE_SNIPPET_URL  = 'https://omnisnippet1.com/inshop/launcher-v2.js';
+
+// Application this plugin registers itself as in the Omnisend app market.
+const OMNISEND_CORE_OAUTH_CLIENT_NAME = 'WordPress';
 
 // Omnisend for Woo plugin.
 const OMNISEND_CORE_WOOCOMMERCE_PLUGIN_API_KEY_OPTION = 'omnisend_api_key';
@@ -61,6 +65,7 @@ class Omnisend_Core_Bootstrap {
 		add_action( 'wp_enqueue_scripts', 'Omnisend_Core_Bootstrap::load_omnisend_site_styles' );
 		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'Omnisend_Core_Bootstrap::add_links_in_plugin_settings' );
 
+		add_action( 'admin_init', 'Omnisend\Internal\Connection::handle_oauth_request' );
 		add_action( 'admin_init', 'Omnisend\Internal\Connection::connect_with_omnisend_for_woo_plugin' );
 		add_action( 'admin_init', 'Omnisend_Core_Bootstrap::add_privacy_policy_content' );
 

--- a/omnisend/class-omnisend-core-bootstrap.php
+++ b/omnisend/class-omnisend-core-bootstrap.php
@@ -34,7 +34,10 @@ const OMNISEND_CORE_CRON_SCHEDULE_EVERY_MINUTE = 'omni_send_core_every_minute';
 const OMNISEND_CORE_CRON_SYNC_CONTACT = 'omni_send_cron_sync_contacts';
 
 // Change for different environment.
-const OMNISEND_CORE_API          = 'https://api.omnisend.com/api';
+const OMNISEND_CORE_API = 'https://api.omnisend.com/api';
+// Retained deprecated base, used only by API key connections for the account write. The /api account routes
+// require permissions brand API keys do not have, and brand writes on /api are OAuth only.
+const OMNISEND_CORE_API_V3       = 'https://api.omnisend.com/v3';
 const OMNISEND_CORE_OAUTH_ISSUER = 'https://app.omnisend.com';
 const OMNISEND_CORE_SNIPPET_URL  = 'https://omnisnippet1.com/inshop/launcher-v2.js';
 

--- a/omnisend/includes/Internal/V1/class-client.php
+++ b/omnisend/includes/Internal/V1/class-client.php
@@ -256,14 +256,27 @@ class Client implements \Omnisend\SDK\V1\Client {
 			'platformVersion' => get_bloginfo( 'version' ),
 		);
 
-		// Brand settings may only be written with an OAuth token, so API key connections keep using the account endpoint.
-		$url = $this->is_oauth_connection() ? OMNISEND_CORE_API . '/brands/current' : OMNISEND_CORE_API . '/accounts/' . $brand_id;
+		// Brand settings may only be written with an OAuth token, so API key connections stay on the
+		// retained deprecated /v3 account call, which is the only account write they are allowed to make.
+		if ( $this->is_oauth_connection() ) {
+			$url     = OMNISEND_CORE_API . '/brands/current';
+			$headers = $this->get_request_headers();
+		} else {
+			$url     = OMNISEND_CORE_API_V3 . '/accounts/' . $brand_id;
+			$headers = ApiRequest::legacy_api_key_headers(
+				$this->api_key,
+				array(
+					'X-INTEGRATION-NAME'    => $this->plugin_name,
+					'X-INTEGRATION-VERSION' => $this->plugin_version,
+				)
+			);
+		}
 
 		$response = wp_remote_post(
 			$url,
 			array(
 				'body'    => wp_json_encode( $data ),
-				'headers' => $this->get_request_headers(),
+				'headers' => $headers,
 				'timeout' => 10,
 			)
 		);

--- a/omnisend/includes/Internal/V1/class-client.php
+++ b/omnisend/includes/Internal/V1/class-client.php
@@ -23,6 +23,7 @@ use Omnisend\SDK\V1\GetCategoryResponse;
 use Omnisend\SDK\V1\GetProductResponse;
 use Omnisend\Internal\ApiRequest;
 use Omnisend\Internal\ApiResponse;
+use Omnisend\Internal\Options as PluginOptions;
 use Omnisend\Internal\ContactFactory;
 use Omnisend\Internal\CategoryFactory;
 use Omnisend\Internal\ProductFactory;
@@ -41,6 +42,8 @@ class Client implements \Omnisend\SDK\V1\Client {
 	private string $plugin_name;
 	private string $plugin_version;
 	private ?Options $options;
+	private string $authorization          = '';
+	private ?WP_Error $authorization_error = null;
 
 	/**
 	 * @param string $plugin_name
@@ -57,7 +60,7 @@ class Client implements \Omnisend\SDK\V1\Client {
 
 	private function get_request_headers(): array {
 		return ApiRequest::headers(
-			$this->api_key,
+			$this->get_authorization(),
 			array(
 				'X-INTEGRATION-NAME'    => $this->plugin_name,
 				'X-INTEGRATION-VERSION' => $this->plugin_version,
@@ -253,8 +256,11 @@ class Client implements \Omnisend\SDK\V1\Client {
 			'platformVersion' => get_bloginfo( 'version' ),
 		);
 
+		// Brand settings may only be written with an OAuth token, so API key connections keep using the account endpoint.
+		$url = $this->is_oauth_connection() ? OMNISEND_CORE_API . '/brands/current' : OMNISEND_CORE_API . '/accounts/' . $brand_id;
+
 		$response = wp_remote_post(
-			OMNISEND_CORE_API . '/accounts/' . $brand_id,
+			$url,
 			array(
 				'body'    => wp_json_encode( $data ),
 				'headers' => $this->get_request_headers(),
@@ -616,14 +622,43 @@ class Client implements \Omnisend\SDK\V1\Client {
 			$error->add( 'initialisation', 'Client is created with empty plugin version.' );
 		}
 
-		if ( ! $this->api_key ) {
-			$error->add( 'api_key', 'Omnisend plugin is not connected.' );
+		if ( $this->get_authorization() === '' && $this->authorization_error !== null ) {
+			$error->merge_from( $this->authorization_error );
 		}
 
 		return $error;
 	}
 
+	/**
+	 * @return string Authorization header value of the credential this store is connected with, empty when it has none.
+	 */
+	private function get_authorization(): string {
+		if ( $this->authorization !== '' ) {
+			return $this->authorization;
+		}
+
+		$authorization = ApiRequest::authorization( $this->api_key );
+
+		if ( is_wp_error( $authorization ) ) {
+			$this->authorization_error = $authorization;
+
+			return '';
+		}
+
+		$this->authorization = $authorization;
+
+		return $this->authorization;
+	}
+
+	private function is_oauth_connection(): bool {
+		return PluginOptions::get_auth_mode() === PluginOptions::AUTH_MODE_OAUTH;
+	}
+
 	private function get_brand_id(): string {
+		if ( $this->is_oauth_connection() ) {
+			return PluginOptions::get_brand_id();
+		}
+
 		$list = explode( '-', $this->api_key );
 		if ( count( $list ) != 2 ) {
 			return '';

--- a/omnisend/includes/Internal/class-apirequest.php
+++ b/omnisend/includes/Internal/class-apirequest.php
@@ -32,6 +32,23 @@ class ApiRequest {
 		);
 	}
 
+	/**
+	 * Builds the headers of the retained deprecated /v3 account calls, which authenticate with X-API-Key
+	 * and are not versioned.
+	 *
+	 * @param string $api_key Omnisend brand API key.
+	 * @param array  $extra_headers Headers only some callers send, for example the integration name and version.
+	 */
+	public static function legacy_api_key_headers( string $api_key, array $extra_headers = array() ): array {
+		return array_merge(
+			array(
+				'Content-Type' => 'application/json',
+				'X-API-Key'    => $api_key,
+			),
+			$extra_headers
+		);
+	}
+
 	public static function api_key_authorization( string $api_key ): string {
 		return 'Omnisend-API-Key ' . $api_key;
 	}

--- a/omnisend/includes/Internal/class-apirequest.php
+++ b/omnisend/includes/Internal/class-apirequest.php
@@ -7,6 +7,8 @@
 
 namespace Omnisend\Internal;
 
+use WP_Error;
+
 defined( 'ABSPATH' ) || die( 'no direct access' );
 
 class ApiRequest {
@@ -16,17 +18,51 @@ class ApiRequest {
 	/**
 	 * Builds the headers every Omnisend API request is made with.
 	 *
-	 * @param string $api_key Omnisend brand API key.
+	 * @param string $authorization Authorization header value built by one of the methods below.
 	 * @param array  $extra_headers Headers only some callers send, for example the integration name and version.
 	 */
-	public static function headers( string $api_key, array $extra_headers = array() ): array {
+	public static function headers( string $authorization, array $extra_headers = array() ): array {
 		return array_merge(
 			array(
 				'Content-Type'     => 'application/json',
-				'Authorization'    => 'Omnisend-API-Key ' . $api_key,
+				'Authorization'    => $authorization,
 				'Omnisend-Version' => self::VERSION,
 			),
 			$extra_headers
 		);
+	}
+
+	public static function api_key_authorization( string $api_key ): string {
+		return 'Omnisend-API-Key ' . $api_key;
+	}
+
+	public static function bearer_authorization( string $access_token ): string {
+		return 'Bearer ' . $access_token;
+	}
+
+	/**
+	 * Resolves the credential the store is connected with. Stores connected with an API key keep using it,
+	 * stores connected through OAuth use their access token and never fall back to an API key.
+	 *
+	 * @param string $api_key API key the caller was created with, empty on OAuth-connected stores.
+	 *
+	 * @return string|WP_Error Authorization header value, or an error when no usable credential exists.
+	 */
+	public static function authorization( string $api_key ) {
+		if ( Options::get_auth_mode() === Options::AUTH_MODE_OAUTH ) {
+			$access_token = OAuthClient::get_valid_access_token();
+
+			if ( is_wp_error( $access_token ) ) {
+				return $access_token;
+			}
+
+			return self::bearer_authorization( $access_token );
+		}
+
+		if ( $api_key === '' ) {
+			return new WP_Error( 'api_key', 'Omnisend plugin is not connected.' );
+		}
+
+		return self::api_key_authorization( $api_key );
 	}
 }

--- a/omnisend/includes/Internal/class-connection.php
+++ b/omnisend/includes/Internal/class-connection.php
@@ -18,12 +18,19 @@ class Connection {
 
 	private static $signup_url = 'https://app.omnisend.com/registrationv2?utm_source=wordpress_plugin&utm_content=connect_store';
 
+	// phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- WordPress is lowercase as it's required by integration.
+	private const WORDPRESS_PLATFORM    = 'wordpress';
+	private const OAUTH_NONCE_ACTION    = 'omnisend_oauth_connect';
+	private const OAUTH_ERROR_TRANSIENT = 'omni_send_core_oauth_error';
+
 	public static function display(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'omnisend' ) );
 		}
 
 		Options::set_landing_page_visited();
+
+		self::display_oauth_error();
 
 		if ( self::show_connected_store_view() ) {
 			?>
@@ -94,10 +101,19 @@ class Connection {
 	 * @return array|WP_Error Brand data or an error describing the transport, status or body failure.
 	 */
 	private static function get_account_data( $api_key ) {
+		return self::get_brand_data( ApiRequest::api_key_authorization( $api_key ) );
+	}
+
+	/**
+	 * @param string $authorization Authorization header value of the credential the store is connected with.
+	 *
+	 * @return array|WP_Error Brand data or an error describing the transport, status or body failure.
+	 */
+	private static function get_brand_data( string $authorization ) {
 		$response = wp_remote_get(
 			OMNISEND_CORE_API . '/brands/current',
 			array(
-				'headers' => ApiRequest::headers( $api_key ),
+				'headers' => ApiRequest::headers( $authorization ),
 				'timeout' => 10,
 			)
 		);
@@ -163,41 +179,183 @@ class Connection {
 	}
 
 	/**
+	 * Writes this site into the brand the administrator consented to. The API gateway only allows brand
+	 * writes with an OAuth token, so connecting a store always happens on the OAuth callback.
+	 *
+	 * @param string $authorization Bearer authorization header value.
+	 *
 	 * @return true|WP_Error True when the store is connected, otherwise an error describing the failure.
 	 */
-	private static function connect_store( $api_key ) {
+	private static function connect_store( string $authorization ) {
 		$data = array(
 			'website'         => site_url(),
-			'platform'        => 'wordpress',
+			'platform'        => self::WORDPRESS_PLATFORM,
 			'version'         => OMNISEND_CORE_PLUGIN_VERSION,
 			'phpVersion'      => phpversion(),
 			'platformVersion' => get_bloginfo( 'version' ),
 		);
 
 		$response = wp_remote_post(
-			OMNISEND_CORE_API . '/accounts',
+			OMNISEND_CORE_API . '/brands/current',
 			array(
 				'body'    => wp_json_encode( $data ),
-				'headers' => ApiRequest::headers( $api_key ),
+				'headers' => ApiRequest::headers( $authorization ),
 				'timeout' => 10,
 			)
 		);
 
-		$arr = ApiResponse::parse( $response );
+		$parsed = ApiResponse::parse( $response, false );
 
-		if ( is_wp_error( $arr ) ) {
-			return $arr;
-		}
-
-		if ( ! isset( $arr['connected'] ) || ! is_bool( $arr['connected'] ) ) {
-			return ApiResponse::unexpected_shape_error( 'connected' );
-		}
-
-		if ( $arr['connected'] !== true ) {
-			return ApiResponse::unexpected_value_error( 'connected', 'is false, so the store was not connected' );
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Starts and finishes the OAuth connect flow. New connections and reconnections go through it;
+	 * stores that are already connected with an API key never reach it.
+	 */
+	public static function handle_oauth_request(): void {
+		$action = isset( $_GET['omnisend_oauth'] ) ? sanitize_text_field( wp_unslash( $_GET['omnisend_oauth'] ) ) : '';
+
+		if ( $action !== 'connect' && $action !== 'callback' ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( $action === 'connect' ) {
+			// The callback comes from Omnisend and cannot carry a nonce, so only starting the flow is nonce protected;
+			// the callback is verified with the OAuth state instead.
+			if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ?? '' ) ), self::OAUTH_NONCE_ACTION ) ) {
+				self::finish_oauth_request( 'Connecting to Omnisend failed because the request could not be verified. Please try again.' );
+
+				return;
+			}
+
+			$authorization_url = OAuthClient::get_authorization_url();
+
+			if ( is_wp_error( $authorization_url ) ) {
+				self::finish_oauth_request( self::get_connection_error_message( $authorization_url ) );
+
+				return;
+			}
+
+			self::redirect( $authorization_url );
+
+			return;
+		}
+
+		self::finish_oauth_request( self::complete_oauth_connection() );
+	}
+
+	public static function get_oauth_connect_url(): string {
+		return wp_nonce_url(
+			admin_url( 'admin.php?page=' . OMNISEND_CORE_SETTINGS_PAGE . '&omnisend_oauth=connect' ),
+			self::OAUTH_NONCE_ACTION
+		);
+	}
+
+	/**
+	 * @return string Empty string when the store got connected, otherwise the message to show to the administrator.
+	 */
+	private static function complete_oauth_connection(): string {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Omnisend redirects here, so the request is verified with the OAuth state below.
+		if ( isset( $_GET['error'] ) ) {
+			return 'Omnisend did not authorize this store: ' . sanitize_text_field( wp_unslash( $_GET['error'] ) ) . '.';
+		}
+
+		$code  = isset( $_GET['code'] ) ? sanitize_text_field( wp_unslash( $_GET['code'] ) ) : '';
+		$state = isset( $_GET['state'] ) ? sanitize_text_field( wp_unslash( $_GET['state'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$authorized = OAuthClient::complete_authorization( $code, $state );
+
+		if ( is_wp_error( $authorized ) ) {
+			Options::clear_oauth_tokens();
+
+			return self::get_connection_error_message( $authorized );
+		}
+
+		$access_token = OAuthClient::get_valid_access_token();
+
+		if ( is_wp_error( $access_token ) ) {
+			return self::get_connection_error_message( $access_token );
+		}
+
+		$authorization = ApiRequest::bearer_authorization( $access_token );
+		$brand         = self::get_brand_data( $authorization );
+
+		if ( is_wp_error( $brand ) ) {
+			return self::get_connection_error_message( $brand, 'brands.read' );
+		}
+
+		if ( empty( $brand['brandID'] ) || ! is_string( $brand['brandID'] ) ) {
+			return self::get_connection_error_message( ApiResponse::unexpected_shape_error( 'brandID' ) );
+		}
+
+		if ( ! isset( $brand['platform'] ) || ! is_string( $brand['platform'] ) ) {
+			return self::get_connection_error_message( ApiResponse::unexpected_shape_error( 'platform' ) );
+		}
+
+		if ( $brand['platform'] !== '' && $brand['platform'] !== self::WORDPRESS_PLATFORM ) {
+			Options::clear_oauth_tokens();
+
+			return 'The connection did not go through. This Omnisend account is connected to another platform (' . $brand['platform'] . ').';
+		}
+
+		$connected = self::connect_store( $authorization );
+
+		if ( is_wp_error( $connected ) ) {
+			// Only the tokens this flow obtained are dropped, so a store that was connected with an API key before keeps working.
+			Options::clear_oauth_tokens();
+
+			return self::get_connection_error_message( $connected, 'brands.write' );
+		}
+
+		Options::set_brand_id( $brand['brandID'] );
+		Options::set_store_connected();
+		self::schedule_contact_sync();
+
+		return '';
+	}
+
+	private static function finish_oauth_request( string $error_message ): void {
+		if ( $error_message !== '' ) {
+			set_transient( self::OAUTH_ERROR_TRANSIENT, $error_message, 5 * MINUTE_IN_SECONDS );
+		}
+
+		self::redirect( admin_url( 'admin.php?page=' . OMNISEND_CORE_SETTINGS_PAGE ) );
+	}
+
+	private static function redirect( string $url ): void {
+		wp_safe_redirect( $url );
+
+		exit;
+	}
+
+	private static function display_oauth_error(): void {
+		$error_message = get_transient( self::OAUTH_ERROR_TRANSIENT );
+
+		if ( ! is_string( $error_message ) || $error_message === '' ) {
+			return;
+		}
+
+		delete_transient( self::OAUTH_ERROR_TRANSIENT );
+
+		?>
+		<div class="notice notice-error"><p><?php echo esc_html( $error_message ); ?></p></div>
+		<?php
+	}
+
+	private static function schedule_contact_sync(): void {
+		if ( ! wp_next_scheduled( OMNISEND_CORE_CRON_SYNC_CONTACT ) && ! Omnisend_Core_Bootstrap::is_omnisend_woocommerce_plugin_connected() ) {
+			wp_schedule_event( time(), OMNISEND_CORE_CRON_SCHEDULE_EVERY_MINUTE, OMNISEND_CORE_CRON_SYNC_CONTACT );
+		}
 	}
 
 	public static function connect_with_omnisend_for_woo_plugin(): void {
@@ -268,11 +426,15 @@ class Connection {
 		return null;
 	}
 
+	/**
+	 * Connects a store with an API key its administrator pasted. New brands are connected through OAuth,
+	 * because only OAuth credentials may write brand settings, so this only accepts brands Omnisend already
+	 * knows as WordPress stores.
+	 */
 	public static function omnisend_post_connection() {
 		$connected = Options::is_store_connected();
 
-		// phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
-		$wordpress_platform = 'wordpress'; // WordPress is lowercase as it's required by integration.
+		$wordpress_platform = self::WORDPRESS_PLATFORM;
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return rest_ensure_response(
@@ -352,33 +514,21 @@ class Connection {
 				);
 			}
 
-			$connected = false;
-			if ( $response['platform'] === $wordpress_platform ) {
-				$connected = true;
-			}
-
 			if ( $response['platform'] === '' ) {
-				$connected = self::connect_store( $api_key );
-
-				if ( is_wp_error( $connected ) ) {
-					Options::disconnect(); // Store was not connected, clean up.
-					return rest_ensure_response(
-						array(
-							'success' => false,
-							'error'   => self::get_connection_error_message( $connected, 'accounts.write' ),
-						)
-					);
-				}
+				return rest_ensure_response(
+					array(
+						'success' => false,
+						'error'   => 'This Omnisend account has no store connected yet. Use the "Connect Omnisend" button to connect it.',
+					)
+				);
 			}
 
-			if ( $connected ) {
+			if ( $response['platform'] === $wordpress_platform ) {
 				Options::set_api_key( $api_key );
 				Options::set_brand_id( $brand_id );
 				Options::set_store_connected();
+				self::schedule_contact_sync();
 
-				if ( ! wp_next_scheduled( OMNISEND_CORE_CRON_SYNC_CONTACT ) && ! Omnisend_Core_Bootstrap::is_omnisend_woocommerce_plugin_connected() ) {
-					wp_schedule_event( time(), OMNISEND_CORE_CRON_SCHEDULE_EVERY_MINUTE, OMNISEND_CORE_CRON_SYNC_CONTACT );
-				}
 				return rest_ensure_response(
 					array(
 						'success' => true,

--- a/omnisend/includes/Internal/class-connection.php
+++ b/omnisend/includes/Internal/class-connection.php
@@ -214,6 +214,43 @@ class Connection {
 	}
 
 	/**
+	 * Writes this site into the brand the pasted API key belongs to. This is the retained deprecated /v3 call:
+	 * brand API keys are rejected by the /api account routes and may not write brand settings at all.
+	 *
+	 * @return true|WP_Error True when the store is connected, otherwise an error describing the failure.
+	 */
+	private static function connect_store_with_api_key( string $api_key ) {
+		$data = array(
+			'website'         => site_url(),
+			'platform'        => self::WORDPRESS_PLATFORM,
+			'version'         => OMNISEND_CORE_PLUGIN_VERSION,
+			'phpVersion'      => phpversion(),
+			'platformVersion' => get_bloginfo( 'version' ),
+		);
+
+		$response = wp_remote_post(
+			OMNISEND_CORE_API_V3 . '/accounts',
+			array(
+				'body'    => wp_json_encode( $data ),
+				'headers' => ApiRequest::legacy_api_key_headers( $api_key ),
+				'timeout' => 10,
+			)
+		);
+
+		$parsed = ApiResponse::parse( $response );
+
+		if ( is_wp_error( $parsed ) ) {
+			return $parsed;
+		}
+
+		if ( empty( $parsed['verified'] ) ) {
+			return ApiResponse::unexpected_value_error( 'verified', 'is not set, so Omnisend did not verify this store' );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Starts and finishes the OAuth connect flow. New connections and reconnections go through it;
 	 * stores that are already connected with an API key never reach it.
 	 */
@@ -427,9 +464,8 @@ class Connection {
 	}
 
 	/**
-	 * Connects a store with an API key its administrator pasted. New brands are connected through OAuth,
-	 * because only OAuth credentials may write brand settings, so this only accepts brands Omnisend already
-	 * knows as WordPress stores.
+	 * Connects a store with an API key its administrator pasted. Brands Omnisend does not know a platform for
+	 * are written with the retained deprecated /v3 account call, because API keys may not write brand settings on /api.
 	 */
 	public static function omnisend_post_connection() {
 		$connected = Options::is_store_connected();
@@ -515,10 +551,26 @@ class Connection {
 			}
 
 			if ( $response['platform'] === '' ) {
+				$connected_store = self::connect_store_with_api_key( $api_key );
+
+				if ( is_wp_error( $connected_store ) ) {
+					return rest_ensure_response(
+						array(
+							'success' => false,
+							'error'   => self::get_connection_error_message( $connected_store ),
+						)
+					);
+				}
+
+				Options::set_api_key( $api_key );
+				Options::set_brand_id( $brand_id );
+				Options::set_store_connected();
+				self::schedule_contact_sync();
+
 				return rest_ensure_response(
 					array(
-						'success' => false,
-						'error'   => 'This Omnisend account has no store connected yet. Use the "Connect Omnisend" button to connect it.',
+						'success' => true,
+						'error'   => '',
 					)
 				);
 			}

--- a/omnisend/includes/Internal/class-oauthclient.php
+++ b/omnisend/includes/Internal/class-oauthclient.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Omnisend plugin
+ *
+ * @package OmnisendPlugin
+ */
+
+namespace Omnisend\Internal;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || die( 'no direct access' );
+
+class OAuthClient {
+
+	const ERROR_REGISTRATION = 'omnisend_oauth_registration_failed';
+	const ERROR_STATE        = 'omnisend_oauth_state_mismatch';
+	const ERROR_TOKEN        = 'omnisend_oauth_token_failed';
+	const ERROR_REFRESH      = 'omnisend_oauth_refresh_failed';
+	const ERROR_NO_TOKEN     = 'omnisend_oauth_no_token';
+
+	const SCOPES = 'brands.read brands.write contacts.read contacts.write events.write products.read products.write';
+
+	private const STATE_TRANSIENT = 'omni_send_core_oauth_state';
+	private const STATE_LIFETIME  = 900;
+
+	/**
+	 * Access tokens are refreshed slightly before they expire so a request does not fail on a token
+	 * that expires while it is in flight.
+	 */
+	private const EXPIRY_SKEW = 60;
+
+	/**
+	 * Starts the connect flow: registers this site as an OAuth client if it has no credentials yet and
+	 * returns the URL the administrator is sent to for consent.
+	 *
+	 * @return string|WP_Error
+	 */
+	public static function get_authorization_url() {
+		if ( Options::get_oauth_client_id() === '' || Options::get_oauth_client_secret() === '' ) {
+			$registered = self::register_client();
+
+			if ( is_wp_error( $registered ) ) {
+				return $registered;
+			}
+		}
+
+		$state = wp_generate_password( 32, false );
+		set_transient( self::STATE_TRANSIENT, $state, self::STATE_LIFETIME );
+
+		$query = array(
+			'response_type' => 'code',
+			'client_id'     => Options::get_oauth_client_id(),
+			'redirect_uri'  => self::get_redirect_uri(),
+			'scope'         => self::SCOPES,
+			'state'         => $state,
+		);
+
+		return add_query_arg( $query, OMNISEND_CORE_OAUTH_ISSUER . '/oauth2/authorize' );
+	}
+
+	/**
+	 * Finishes the connect flow by validating the state and exchanging the authorization code for tokens.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function complete_authorization( string $code, string $state ) {
+		$expected_state = get_transient( self::STATE_TRANSIENT );
+		delete_transient( self::STATE_TRANSIENT );
+
+		if ( ! is_string( $expected_state ) || $expected_state === '' || ! hash_equals( $expected_state, $state ) ) {
+			return new WP_Error( self::ERROR_STATE, 'The Omnisend authorization response did not match this site. Please try connecting again.' );
+		}
+
+		if ( $code === '' ) {
+			return new WP_Error( self::ERROR_TOKEN, 'Omnisend did not return an authorization code. Please try connecting again.' );
+		}
+
+		$tokens = self::request_tokens(
+			array(
+				'grant_type'   => 'authorization_code',
+				'code'         => $code,
+				'redirect_uri' => self::get_redirect_uri(),
+			)
+		);
+
+		if ( is_wp_error( $tokens ) ) {
+			return new WP_Error( self::ERROR_TOKEN, $tokens->get_error_message() );
+		}
+
+		return self::store_tokens( $tokens, '' );
+	}
+
+	/**
+	 * @return string|WP_Error Access token usable right now, or an error when the store has to be reconnected.
+	 */
+	public static function get_valid_access_token() {
+		$access_token = Options::get_oauth_access_token();
+
+		if ( $access_token === '' ) {
+			return new WP_Error( self::ERROR_NO_TOKEN, 'The store is not connected to Omnisend. Please connect it again.' );
+		}
+
+		if ( Options::get_oauth_token_expires_at() > time() + self::EXPIRY_SKEW ) {
+			return $access_token;
+		}
+
+		$refreshed = self::refresh_tokens();
+
+		if ( is_wp_error( $refreshed ) ) {
+			return $refreshed;
+		}
+
+		return Options::get_oauth_access_token();
+	}
+
+	public static function get_redirect_uri(): string {
+		return admin_url( 'admin.php?page=' . OMNISEND_CORE_SETTINGS_PAGE . '&omnisend_oauth=callback' );
+	}
+
+	/**
+	 * @return true|WP_Error
+	 */
+	private static function refresh_tokens() {
+		$refresh_token = Options::get_oauth_refresh_token();
+
+		if ( $refresh_token === '' ) {
+			return new WP_Error( self::ERROR_REFRESH, 'The Omnisend access token expired and this store has no refresh token. Please connect it again.' );
+		}
+
+		$tokens = self::request_tokens(
+			array(
+				'grant_type'    => 'refresh_token',
+				'refresh_token' => $refresh_token,
+			)
+		);
+
+		if ( is_wp_error( $tokens ) ) {
+			return new WP_Error( self::ERROR_REFRESH, $tokens->get_error_message() );
+		}
+
+		return self::store_tokens( $tokens, $refresh_token );
+	}
+
+	/**
+	 * @return array|WP_Error Token endpoint response.
+	 */
+	private static function request_tokens( array $grant ) {
+		$client_id     = Options::get_oauth_client_id();
+		$client_secret = Options::get_oauth_client_secret();
+
+		if ( $client_id === '' || $client_secret === '' ) {
+			return new WP_Error( self::ERROR_TOKEN, 'This site is not registered as an Omnisend OAuth client. Please connect it again.' );
+		}
+
+		$response = wp_remote_post(
+			OMNISEND_CORE_OAUTH_ISSUER . '/oauth2/token',
+			array(
+				'body'    => array_merge(
+					$grant,
+					array(
+						'client_id'     => $client_id,
+						'client_secret' => $client_secret,
+					)
+				),
+				'headers' => array(
+					'Content-Type' => 'application/x-www-form-urlencoded',
+				),
+				'timeout' => 10,
+			)
+		);
+
+		return ApiResponse::parse( $response );
+	}
+
+	/**
+	 * @param array  $tokens                Token endpoint response.
+	 * @param string $current_refresh_token Refresh token to keep when the response does not rotate it.
+	 *
+	 * @return true|WP_Error
+	 */
+	private static function store_tokens( array $tokens, string $current_refresh_token ) {
+		if ( ! isset( $tokens['access_token'] ) || ! is_string( $tokens['access_token'] ) || $tokens['access_token'] === '' ) {
+			return ApiResponse::unexpected_shape_error( 'access_token' );
+		}
+
+		$refresh_token = $current_refresh_token;
+		if ( isset( $tokens['refresh_token'] ) && is_string( $tokens['refresh_token'] ) && $tokens['refresh_token'] !== '' ) {
+			$refresh_token = $tokens['refresh_token'];
+		}
+
+		if ( ! isset( $tokens['expires_in'] ) || ! is_numeric( $tokens['expires_in'] ) ) {
+			return ApiResponse::unexpected_shape_error( 'expires_in' );
+		}
+
+		Options::set_oauth_tokens( $tokens['access_token'], $refresh_token, time() + intval( $tokens['expires_in'] ) );
+
+		return true;
+	}
+
+	/**
+	 * @return true|WP_Error
+	 */
+	private static function register_client() {
+		$response = wp_remote_post(
+			OMNISEND_CORE_OAUTH_ISSUER . '/oauth2/register',
+			array(
+				'body'    => wp_json_encode(
+					array(
+						'client_name'   => OMNISEND_CORE_OAUTH_CLIENT_NAME,
+						'client_uri'    => site_url(),
+						'redirect_uris' => array( self::get_redirect_uri() ),
+						'grant_types'   => array( 'authorization_code', 'refresh_token' ),
+						'scope'         => self::SCOPES,
+					)
+				),
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'timeout' => 10,
+			)
+		);
+
+		$registration = ApiResponse::parse( $response );
+
+		if ( is_wp_error( $registration ) ) {
+			return self::registration_error( $registration );
+		}
+
+		if ( ! isset( $registration['client_id'] ) || ! is_string( $registration['client_id'] ) || $registration['client_id'] === '' ) {
+			return self::registration_error( ApiResponse::unexpected_shape_error( 'client_id' ) );
+		}
+
+		if ( ! isset( $registration['client_secret'] ) || ! is_string( $registration['client_secret'] ) || $registration['client_secret'] === '' ) {
+			return self::registration_error( ApiResponse::unexpected_shape_error( 'client_secret' ) );
+		}
+
+		Options::set_oauth_client( $registration['client_id'], $registration['client_secret'] );
+
+		return true;
+	}
+
+	private static function registration_error( WP_Error $error ): WP_Error {
+		return new WP_Error( self::ERROR_REGISTRATION, 'Registering this site with Omnisend did not go through. Details: ' . $error->get_error_message() );
+	}
+}

--- a/omnisend/includes/Internal/class-options.php
+++ b/omnisend/includes/Internal/class-options.php
@@ -15,6 +15,9 @@ define( 'NOTIFICATION_DISABLED', 'disabled' );
 
 class Options {
 
+	const AUTH_MODE_API_KEY = 'api_key';
+	const AUTH_MODE_OAUTH   = 'oauth';
+
 	// omni_send instead of omnisend used to distinct and not interfere with Omnisend for Woo plugin.
 	private const OPTION_API_KEY                         = 'omni_send_core_api_key';
 	private const OPTION_BRAND_ID                        = 'omni_send_core_brand_id';
@@ -22,6 +25,12 @@ class Options {
 	private const OPTION_LANDING_PAGE_VISITED            = 'omni_send_core_landing_page_visited';
 	private const OPTION_LANDING_PAGE_VISIT_LAST_TIME    = 'omni_send_core_landing_page_last_visit_time';
 	private const OPTION_LANDING_PAGE_NOTIFICATION_STATE = 'omni_send_core_landing_page_notification_state';
+	private const OPTION_AUTH_MODE                       = 'omni_send_core_auth_mode';
+	private const OPTION_OAUTH_CLIENT_ID                 = 'omni_send_core_oauth_client_id';
+	private const OPTION_OAUTH_CLIENT_SECRET             = 'omni_send_core_oauth_client_secret';
+	private const OPTION_OAUTH_ACCESS_TOKEN              = 'omni_send_core_oauth_access_token';
+	private const OPTION_OAUTH_REFRESH_TOKEN             = 'omni_send_core_oauth_refresh_token';
+	private const OPTION_OAUTH_TOKEN_EXPIRES_AT          = 'omni_send_core_oauth_token_expires_at';
 
 	public static function get_api_key(): string {
 		$api_key = get_option( self::OPTION_API_KEY );
@@ -60,7 +69,82 @@ class Options {
 	}
 
 	public static function is_connected(): bool {
-		return self::is_store_connected() && self::get_api_key();
+		return self::is_store_connected() && self::has_credentials();
+	}
+
+	public static function has_credentials(): bool {
+		if ( self::get_auth_mode() === self::AUTH_MODE_OAUTH ) {
+			return self::get_oauth_access_token() !== '';
+		}
+
+		return self::get_api_key() !== '';
+	}
+
+	/**
+	 * Stores that were connected before OAuth existed have no stored mode, so an API key alone means API-key mode.
+	 * Only an explicit connect or reconnect writes the OAuth mode.
+	 */
+	public static function get_auth_mode(): string {
+		$mode = get_option( self::OPTION_AUTH_MODE );
+
+		if ( $mode === self::AUTH_MODE_OAUTH || $mode === self::AUTH_MODE_API_KEY ) {
+			return $mode;
+		}
+
+		return self::get_api_key() === '' ? '' : self::AUTH_MODE_API_KEY;
+	}
+
+	public static function get_oauth_client_id(): string {
+		$client_id = get_option( self::OPTION_OAUTH_CLIENT_ID );
+
+		return is_string( $client_id ) ? $client_id : '';
+	}
+
+	public static function get_oauth_client_secret(): string {
+		$client_secret = get_option( self::OPTION_OAUTH_CLIENT_SECRET );
+
+		return is_string( $client_secret ) ? $client_secret : '';
+	}
+
+	public static function get_oauth_access_token(): string {
+		$access_token = get_option( self::OPTION_OAUTH_ACCESS_TOKEN );
+
+		return is_string( $access_token ) ? $access_token : '';
+	}
+
+	public static function get_oauth_refresh_token(): string {
+		$refresh_token = get_option( self::OPTION_OAUTH_REFRESH_TOKEN );
+
+		return is_string( $refresh_token ) ? $refresh_token : '';
+	}
+
+	public static function get_oauth_token_expires_at(): int {
+		$expires_at = get_option( self::OPTION_OAUTH_TOKEN_EXPIRES_AT );
+
+		return is_numeric( $expires_at ) ? intval( $expires_at ) : 0;
+	}
+
+	public static function set_oauth_client( string $client_id, string $client_secret ): void {
+		update_option( self::OPTION_OAUTH_CLIENT_ID, $client_id );
+		update_option( self::OPTION_OAUTH_CLIENT_SECRET, $client_secret );
+	}
+
+	public static function set_oauth_tokens( string $access_token, string $refresh_token, int $expires_at ): void {
+		update_option( self::OPTION_OAUTH_ACCESS_TOKEN, $access_token );
+		update_option( self::OPTION_OAUTH_REFRESH_TOKEN, $refresh_token );
+		update_option( self::OPTION_OAUTH_TOKEN_EXPIRES_AT, $expires_at );
+		update_option( self::OPTION_AUTH_MODE, self::AUTH_MODE_OAUTH );
+	}
+
+	/**
+	 * Drops the tokens of a connect attempt that did not finish. The API key is left alone so a store that
+	 * was connected with one before keeps working.
+	 */
+	public static function clear_oauth_tokens(): void {
+		delete_option( self::OPTION_OAUTH_ACCESS_TOKEN );
+		delete_option( self::OPTION_OAUTH_REFRESH_TOKEN );
+		delete_option( self::OPTION_OAUTH_TOKEN_EXPIRES_AT );
+		delete_option( self::OPTION_AUTH_MODE );
 	}
 
 	public static function get_landing_page_last_visit_time(): int {
@@ -100,6 +184,10 @@ class Options {
 
 	public static function disconnect(): void {
 		delete_option( self::OPTION_API_KEY );
+		delete_option( self::OPTION_AUTH_MODE );
+		delete_option( self::OPTION_OAUTH_ACCESS_TOKEN );
+		delete_option( self::OPTION_OAUTH_REFRESH_TOKEN );
+		delete_option( self::OPTION_OAUTH_TOKEN_EXPIRES_AT );
 		delete_option( self::OPTION_BRAND_ID );
 		delete_option( self::OPTION_STORE_CONNECTED );
 		delete_option( self::OPTION_LANDING_PAGE_VISITED );
@@ -110,5 +198,7 @@ class Options {
 
 	public static function delete_all(): void {
 		self::disconnect();
+		delete_option( self::OPTION_OAUTH_CLIENT_ID );
+		delete_option( self::OPTION_OAUTH_CLIENT_SECRET );
 	}
 }

--- a/omnisend/includes/SDK/V1/class-omnisend.php
+++ b/omnisend/includes/SDK/V1/class-omnisend.php
@@ -37,6 +37,6 @@ class Omnisend {
 	 * @return bool
 	 */
 	public static function is_connected(): bool {
-		return Options::get_api_key() != '';
+		return Options::has_credentials();
 	}
 }

--- a/omnisend/view/landing-page.html
+++ b/omnisend/view/landing-page.html
@@ -1,6 +1,6 @@
 <?php
     use Omnisend\Internal\Connection;
-    $nonce = wp_create_nonce( 'show_connection_form' );
+    $connect_url = Connection::get_oauth_connect_url();
 ?>
 
 <div class="omnisend-landing-page-header">
@@ -20,9 +20,9 @@
                 <a class="omnisend-button-primary" href="<?php echo Omnisend\Internal\Connection::$landing_page_url;?>" target="_blank">
                     Explore Omnisend
                 </a>
-                <a class="omnisend-button" href="admin.php?page=omnisend&action=show_connection_form&_wpnonce=<?php echo $nonce; ?>"> Connect Omnisend </a>
+                <a class="omnisend-button" href="<?php echo esc_url( $connect_url ); ?>"> Connect Omnisend </a>
                 <?php else: ?>
-                <a class="omnisend-button-primary" href="admin.php?page=omnisend&action=show_connection_form&_wpnonce=<?php echo $nonce; ?>"> Connect Omnisend </a>
+                <a class="omnisend-button-primary" href="<?php echo esc_url( $connect_url ); ?>"> Connect Omnisend </a>
                 <?php endif; ?>
             </div>
         </div>
@@ -100,7 +100,7 @@
                     <a class="omnisend-button-green" href="<?php echo Omnisend\Internal\Connection::$landing_page_url;?>" target="_blank">
                         Explore Omnisend
                     </a>
-                    <a class="omnisend-button-white" href="admin.php?page=omnisend&action=show_connection_form&_wpnonce=<?php echo $nonce; ?>"> Connect Omnisend </a>
+                    <a class="omnisend-button-white" href="<?php echo esc_url( $connect_url ); ?>"> Connect Omnisend </a>
                 </div>
             </div>
         </div>

--- a/tests/Omnisend/Internal/AuthModeTest.php
+++ b/tests/Omnisend/Internal/AuthModeTest.php
@@ -135,6 +135,39 @@ final class AuthModeTest extends TestCase
         $this->assertEquals('https://app.omnisend.com/oauth2/token', WP_Http_Test_Stub::last_request()['url']);
     }
 
+    public function test_sdk_connect_store_of_an_api_key_install_uses_the_retained_v3_account_write(): void
+    {
+        $this->connect_with_api_key();
+
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"verified":true}'));
+
+        $response = $this->client()->connect_store('wordpress');
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('https://api.omnisend.com/v3/accounts/brandid', $request['url']);
+        $this->assertEquals('brandid-secret', $request['args']['headers']['X-API-Key']);
+        $this->assertArrayNotHasKey('Authorization', $request['args']['headers']);
+        $this->assertEquals('test-plugin', $request['args']['headers']['X-INTEGRATION-NAME']);
+    }
+
+    public function test_sdk_connect_store_of_an_oauth_install_writes_the_current_brand(): void
+    {
+        $this->connect_with_oauth(DAY_IN_SECONDS);
+
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{}'));
+
+        $response = $this->client()->connect_store('wordpress');
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('https://api.omnisend.com/api/brands/current', $request['url']);
+        $this->assertEquals('Bearer access-1', $request['args']['headers']['Authorization']);
+        $this->assertEquals('2026-03-15', $request['args']['headers']['Omnisend-Version']);
+    }
+
     public function test_store_without_any_credential_is_not_connected(): void
     {
         $this->assertEquals('', Options::get_auth_mode());

--- a/tests/Omnisend/Internal/AuthModeTest.php
+++ b/tests/Omnisend/Internal/AuthModeTest.php
@@ -1,0 +1,144 @@
+<?php
+namespace Omnisend\Internal;
+
+use Omnisend\Internal\V1\Client;
+use Omnisend\SDK\V1\Contact;
+use Omnisend\SDK\V1\Omnisend;
+use PHPUnit\Framework\TestCase;
+use WP_Http_Test_Stub;
+
+require_once( __DIR__ . '/../../dependencies/dependencies.php' );
+
+final class AuthModeTest extends TestCase
+{
+    private const API_KEY = 'brandid-secret';
+
+    protected function setUp(): void
+    {
+        WP_Http_Test_Stub::reset();
+        wp_test_reset_options();
+    }
+
+    private function client(): Client
+    {
+        return new Client(Options::get_api_key(), 'test-plugin', '1.0.0', null);
+    }
+
+    private function connect_with_api_key(): void
+    {
+        Options::set_api_key(self::API_KEY);
+        Options::set_brand_id('brandid');
+        Options::set_store_connected();
+    }
+
+    private function connect_with_oauth(int $expires_in): void
+    {
+        Options::set_brand_id('brand-1');
+        Options::set_store_connected();
+        Options::set_oauth_client('client-1', 'secret-1');
+        Options::set_oauth_tokens('access-1', 'refresh-1', time() + $expires_in);
+    }
+
+    private function request_contact(): array
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contacts":[{"id":"contact-1","email":"test@example.com"}]}'));
+
+        $this->client()->get_contact_by_email('test@example.com');
+
+        return WP_Http_Test_Stub::last_request();
+    }
+
+    public function test_install_connected_before_oauth_existed_keeps_using_its_api_key(): void
+    {
+        $this->connect_with_api_key();
+
+        $this->assertEquals(Options::AUTH_MODE_API_KEY, Options::get_auth_mode());
+        $this->assertTrue(Options::is_connected());
+        $this->assertTrue(Omnisend::is_connected());
+
+        $request = $this->request_contact();
+
+        $this->assertEquals('Omnisend-API-Key brandid-secret', $request['args']['headers']['Authorization']);
+        $this->assertCount(1, WP_Http_Test_Stub::$requests);
+    }
+
+    public function test_registered_oauth_client_alone_does_not_switch_an_api_key_install_to_oauth(): void
+    {
+        $this->connect_with_api_key();
+        Options::set_oauth_client('client-1', 'secret-1');
+
+        $this->assertEquals(Options::AUTH_MODE_API_KEY, Options::get_auth_mode());
+        $this->assertEquals('Omnisend-API-Key brandid-secret', $this->request_contact()['args']['headers']['Authorization']);
+    }
+
+    public function test_oauth_connection_authenticates_with_the_access_token(): void
+    {
+        $this->connect_with_oauth(DAY_IN_SECONDS);
+
+        $this->assertEquals(Options::AUTH_MODE_OAUTH, Options::get_auth_mode());
+        $this->assertTrue(Omnisend::is_connected());
+
+        $request = $this->request_contact();
+
+        $this->assertEquals('Bearer access-1', $request['args']['headers']['Authorization']);
+        $this->assertCount(1, WP_Http_Test_Stub::$requests);
+    }
+
+    public function test_expired_access_token_is_refreshed_before_the_request(): void
+    {
+        $this->connect_with_oauth(-DAY_IN_SECONDS);
+
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"access_token":"access-2","refresh_token":"refresh-2","expires_in":3600}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contacts":[{"id":"contact-1","email":"test@example.com"}]}'));
+
+        $response = $this->client()->get_contact_by_email('test@example.com');
+
+        $this->assertFalse($response->get_wp_error()->has_errors());
+
+        $refresh = WP_Http_Test_Stub::$requests[0];
+        $this->assertEquals('https://app.omnisend.com/oauth2/token', $refresh['url']);
+        $this->assertEquals('refresh_token', $refresh['args']['body']['grant_type']);
+        $this->assertEquals('refresh-1', $refresh['args']['body']['refresh_token']);
+
+        $this->assertEquals('Bearer access-2', WP_Http_Test_Stub::last_request()['args']['headers']['Authorization']);
+        $this->assertEquals('access-2', Options::get_oauth_access_token());
+        $this->assertEquals('refresh-2', Options::get_oauth_refresh_token());
+    }
+
+    public function test_refresh_response_without_a_new_refresh_token_keeps_the_current_one(): void
+    {
+        $this->connect_with_oauth(-DAY_IN_SECONDS);
+
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"access_token":"access-2","expires_in":3600}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"contacts":[{"id":"contact-1","email":"test@example.com"}]}'));
+
+        $this->client()->get_contact_by_email('test@example.com');
+
+        $this->assertEquals('refresh-1', Options::get_oauth_refresh_token());
+    }
+
+    public function test_failed_refresh_is_reported_and_never_falls_back_to_an_api_key(): void
+    {
+        $this->connect_with_oauth(-DAY_IN_SECONDS);
+        Options::set_api_key(self::API_KEY);
+
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(400, '{"error":"invalid_grant"}'));
+
+        $contact = new Contact();
+        $contact->set_email('test@example.com');
+
+        $error = $this->client()->save_contact($contact)->get_wp_error();
+
+        $this->assertTrue($error->has_errors());
+        $this->assertContains(OAuthClient::ERROR_REFRESH, $error->get_error_codes());
+        $this->assertCount(1, WP_Http_Test_Stub::$requests);
+        $this->assertEquals('https://app.omnisend.com/oauth2/token', WP_Http_Test_Stub::last_request()['url']);
+    }
+
+    public function test_store_without_any_credential_is_not_connected(): void
+    {
+        $this->assertEquals('', Options::get_auth_mode());
+        $this->assertFalse(Options::is_connected());
+        $this->assertFalse(Omnisend::is_connected());
+    }
+}

--- a/tests/Omnisend/Internal/ConnectionTest.php
+++ b/tests/Omnisend/Internal/ConnectionTest.php
@@ -160,13 +160,31 @@ final class ConnectionTest extends TestCase
         $this->assertEquals('2026-03-15', $request['args']['headers']['Omnisend-Version']);
     }
 
-    public function test_api_key_connect_of_brand_without_store_is_sent_to_the_oauth_flow(): void
+    public function test_api_key_connect_of_brand_without_store_uses_the_retained_v3_account_write(): void
     {
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"verified":true}'));
 
-        $this->assertStringContainsString('Use the "Connect Omnisend" button', $this->connection_error());
+        $response = Connection::omnisend_post_connection();
+
+        $this->assertTrue($response['success']);
+        $this->assertTrue(Options::is_store_connected());
+        $this->assertEquals(Options::AUTH_MODE_API_KEY, Options::get_auth_mode());
+
+        $request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('https://api.omnisend.com/v3/accounts', $request['url']);
+        $this->assertEquals('brandid-secret', $request['args']['headers']['X-API-Key']);
+        $this->assertArrayNotHasKey('Authorization', $request['args']['headers']);
+        $this->assertEquals('wordpress', json_decode($request['args']['body'], true)['platform']);
+    }
+
+    public function test_api_key_connect_of_brand_without_store_fails_when_omnisend_does_not_verify_it(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"verified":false}'));
+
+        $this->assertStringContainsString('verified in response', $this->connection_error());
         $this->assertFalse(Options::is_store_connected());
-        $this->assertCount(1, WP_Http_Test_Stub::$requests);
     }
 
     public function test_non_boolean_connected_in_brand_response_is_rejected(): void

--- a/tests/Omnisend/Internal/ConnectionTest.php
+++ b/tests/Omnisend/Internal/ConnectionTest.php
@@ -146,55 +146,27 @@ final class ConnectionTest extends TestCase
         $this->assertTrue(Options::is_store_connected());
     }
 
-    public function test_store_connect_failure_reports_api_error(): void
+    public function test_already_connected_wordpress_store_keeps_authenticating_with_its_api_key(): void
     {
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(403, '{"title":"Forbidden","detail":"This action requires the \'accounts.write\' permission."}'));
-
-        $this->assertStringContainsString('missing required permissions (accounts.write)', $this->connection_error());
-        $this->assertFalse(Options::is_store_connected());
-    }
-
-    public function test_store_connect_success(): void
-    {
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"connected":true}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":"wordpress"}'));
 
         $response = Connection::omnisend_post_connection();
 
         $this->assertTrue($response['success']);
-        $this->assertTrue(Options::is_store_connected());
+        $this->assertEquals(Options::AUTH_MODE_API_KEY, Options::get_auth_mode());
 
         $request = WP_Http_Test_Stub::last_request();
         $this->assertEquals('Omnisend-API-Key brandid-secret', $request['args']['headers']['Authorization']);
         $this->assertEquals('2026-03-15', $request['args']['headers']['Omnisend-Version']);
     }
 
-    public function test_store_connect_without_connected_flag_reports_unexpected_shape(): void
+    public function test_api_key_connect_of_brand_without_store_is_sent_to_the_oauth_flow(): void
     {
         WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{}'));
 
-        $this->assertStringContainsString('connected not found in response.', $this->connection_error());
+        $this->assertStringContainsString('Use the "Connect Omnisend" button', $this->connection_error());
         $this->assertFalse(Options::is_store_connected());
-    }
-
-    public function test_store_connect_with_connected_false_does_not_connect(): void
-    {
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"connected":false}'));
-
-        $this->assertStringContainsString('connected in response is false, so the store was not connected.', $this->connection_error());
-        $this->assertFalse(Options::is_store_connected());
-    }
-
-    public function test_store_connect_with_non_boolean_connected_does_not_connect(): void
-    {
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
-        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"connected":"false"}'));
-
-        $this->assertStringContainsString('connected not found in response.', $this->connection_error());
-        $this->assertFalse(Options::is_store_connected());
+        $this->assertCount(1, WP_Http_Test_Stub::$requests);
     }
 
     public function test_non_boolean_connected_in_brand_response_is_rejected(): void

--- a/tests/Omnisend/Internal/OAuthConnectionTest.php
+++ b/tests/Omnisend/Internal/OAuthConnectionTest.php
@@ -1,0 +1,233 @@
+<?php
+namespace Omnisend\Internal;
+
+use PHPUnit\Framework\TestCase;
+use WP_Http_Test_Stub;
+use WP_Redirect_Test_Exception;
+
+require_once( __DIR__ . '/../../dependencies/dependencies.php' );
+
+final class OAuthConnectionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        WP_Http_Test_Stub::reset();
+        wp_test_reset_options();
+        $GLOBALS['wp_test_nonce_valid'] = true;
+        $_GET = array();
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = array();
+        unset($GLOBALS['wp_test_nonce_valid']);
+    }
+
+    private function registration_response(): array
+    {
+        return WP_Http_Test_Stub::response(201, '{"client_id":"client-1","client_secret":"secret-1"}');
+    }
+
+    private function token_response(string $access_token = 'access-1', string $refresh_token = 'refresh-1', int $expires_in = 2592000): array
+    {
+        return WP_Http_Test_Stub::response(200, json_encode(array(
+            'access_token' => $access_token,
+            'refresh_token' => $refresh_token,
+            'expires_in' => $expires_in,
+        )));
+    }
+
+    /**
+     * Production code exits after redirecting, so the redirect surfaces as an exception in tests.
+     */
+    private function handle_oauth_request(): void
+    {
+        try {
+            Connection::handle_oauth_request();
+        } catch (WP_Redirect_Test_Exception $exception) {
+            return;
+        }
+
+        $this->fail('Handling an OAuth request did not redirect.');
+    }
+
+    private function start_connect(): void
+    {
+        $_GET = array('omnisend_oauth' => 'connect', '_wpnonce' => 'nonce');
+        $this->handle_oauth_request();
+    }
+
+    private function complete_callback(): void
+    {
+        $_GET = array(
+            'omnisend_oauth' => 'callback',
+            'code' => 'auth-code',
+            'state' => get_transient('omni_send_core_oauth_state'),
+        );
+        $this->handle_oauth_request();
+    }
+
+    private function last_redirect(): string
+    {
+        $redirects = $GLOBALS['wp_test_redirects'];
+
+        return $redirects ? $redirects[count($redirects) - 1] : '';
+    }
+
+    private function oauth_error(): string
+    {
+        $error = get_transient('omni_send_core_oauth_error');
+
+        return is_string($error) ? $error : '';
+    }
+
+    public function test_connect_registers_the_client_and_redirects_to_the_consent_screen(): void
+    {
+        WP_Http_Test_Stub::queue($this->registration_response());
+
+        $this->start_connect();
+
+        $registration = WP_Http_Test_Stub::$requests[0];
+        $this->assertEquals('https://app.omnisend.com/oauth2/register', $registration['url']);
+
+        $body = json_decode($registration['args']['body'], true);
+        $this->assertEquals('WordPress', $body['client_name']);
+        $this->assertEquals(array('authorization_code', 'refresh_token'), $body['grant_types']);
+        $this->assertEquals(
+            array('https://example.com/wp-admin/admin.php?page=omnisend&omnisend_oauth=callback'),
+            $body['redirect_uris']
+        );
+
+        $this->assertEquals('client-1', Options::get_oauth_client_id());
+
+        $redirect = $this->last_redirect();
+        $this->assertStringStartsWith('https://app.omnisend.com/oauth2/authorize?', $redirect);
+        $this->assertStringContainsString('client_id=client-1', $redirect);
+        $this->assertStringContainsString('response_type=code', $redirect);
+        $this->assertStringContainsString('brands.write', urldecode($redirect));
+        $this->assertStringContainsString('state=' . get_transient('omni_send_core_oauth_state'), $redirect);
+    }
+
+    public function test_registration_failure_is_reported_and_does_not_start_the_flow(): void
+    {
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(400, '{"title":"invalid_client_metadata"}'));
+
+        $this->start_connect();
+
+        $this->assertStringContainsString('did not go through', $this->oauth_error());
+        $this->assertEquals('', Options::get_oauth_client_id());
+        $this->assertFalse(Options::is_store_connected());
+    }
+
+    public function test_callback_exchanges_the_code_and_connects_the_store_with_the_access_token(): void
+    {
+        WP_Http_Test_Stub::queue($this->registration_response());
+        $this->start_connect();
+
+        WP_Http_Test_Stub::queue($this->token_response());
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1"}'));
+
+        $this->complete_callback();
+
+        $this->assertEquals('', $this->oauth_error());
+        $this->assertTrue(Options::is_store_connected());
+        $this->assertEquals('brand-1', Options::get_brand_id());
+        $this->assertEquals(Options::AUTH_MODE_OAUTH, Options::get_auth_mode());
+        $this->assertEquals('', Options::get_api_key());
+
+        $token_request = WP_Http_Test_Stub::$requests[1];
+        $this->assertEquals('https://app.omnisend.com/oauth2/token', $token_request['url']);
+        $this->assertEquals('authorization_code', $token_request['args']['body']['grant_type']);
+        $this->assertEquals('auth-code', $token_request['args']['body']['code']);
+        $this->assertEquals('secret-1', $token_request['args']['body']['client_secret']);
+
+        $connect_request = WP_Http_Test_Stub::last_request();
+        $this->assertEquals('https://api.omnisend.com/api/brands/current', $connect_request['url']);
+        $this->assertEquals('POST', $connect_request['method']);
+        $this->assertEquals('Bearer access-1', $connect_request['args']['headers']['Authorization']);
+        $this->assertEquals('2026-03-15', $connect_request['args']['headers']['Omnisend-Version']);
+    }
+
+    public function test_callback_with_mismatched_state_does_not_exchange_the_code(): void
+    {
+        WP_Http_Test_Stub::queue($this->registration_response());
+        $this->start_connect();
+
+        $requests_before = count(WP_Http_Test_Stub::$requests);
+
+        $_GET = array(
+            'omnisend_oauth' => 'callback',
+            'code' => 'auth-code',
+            'state' => 'not-the-state-we-sent',
+        );
+        $this->handle_oauth_request();
+
+        $this->assertStringContainsString('did not match this site', $this->oauth_error());
+        $this->assertCount($requests_before, WP_Http_Test_Stub::$requests);
+        $this->assertFalse(Options::is_store_connected());
+    }
+
+    public function test_connect_with_failed_nonce_verification_does_not_start_the_flow(): void
+    {
+        $GLOBALS['wp_test_nonce_valid'] = false;
+
+        $_GET = array('omnisend_oauth' => 'connect', '_wpnonce' => 'nonce');
+        $this->handle_oauth_request();
+
+        $this->assertStringContainsString('could not be verified', $this->oauth_error());
+        $this->assertEmpty(WP_Http_Test_Stub::$requests);
+    }
+
+    public function test_authorization_denied_by_omnisend_is_reported(): void
+    {
+        $_GET = array('omnisend_oauth' => 'callback', 'error' => 'access_denied');
+        $this->handle_oauth_request();
+
+        $this->assertStringContainsString('access_denied', $this->oauth_error());
+        $this->assertEmpty(WP_Http_Test_Stub::$requests);
+    }
+
+    public function test_brand_of_another_platform_is_not_connected(): void
+    {
+        WP_Http_Test_Stub::queue($this->registration_response());
+        $this->start_connect();
+
+        WP_Http_Test_Stub::queue($this->token_response());
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":"shopify"}'));
+
+        $this->complete_callback();
+
+        $this->assertStringContainsString('connected to another platform (shopify)', $this->oauth_error());
+        $this->assertFalse(Options::is_store_connected());
+    }
+
+    public function test_rejected_brand_write_leaves_the_store_disconnected(): void
+    {
+        WP_Http_Test_Stub::queue($this->registration_response());
+        $this->start_connect();
+
+        WP_Http_Test_Stub::queue($this->token_response());
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"brandID":"brand-1","platform":""}'));
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(403, '{"title":"Forbidden","detail":"Missing brands.write scope."}'));
+
+        $this->complete_callback();
+
+        $this->assertStringContainsString('missing required permissions (brands.write)', $this->oauth_error());
+        $this->assertFalse(Options::is_store_connected());
+        $this->assertEquals('', Options::get_oauth_access_token());
+    }
+
+    public function test_token_response_without_access_token_is_rejected(): void
+    {
+        WP_Http_Test_Stub::queue($this->registration_response());
+        $this->start_connect();
+
+        WP_Http_Test_Stub::queue(WP_Http_Test_Stub::response(200, '{"refresh_token":"refresh-1","expires_in":3600}'));
+
+        $this->complete_callback();
+
+        $this->assertStringContainsString('access_token not found in response.', $this->oauth_error());
+        $this->assertEquals('', Options::get_oauth_access_token());
+    }
+}

--- a/tests/dependencies/dependencies.php
+++ b/tests/dependencies/dependencies.php
@@ -45,6 +45,10 @@ if (!defined('OMNISEND_CORE_API')) {
     define('OMNISEND_CORE_API', 'https://api.omnisend.com/api');
 }
 
+if (!defined('OMNISEND_CORE_API_V3')) {
+    define('OMNISEND_CORE_API_V3', 'https://api.omnisend.com/v3');
+}
+
 function do_action($args) {
     return;
 }

--- a/tests/dependencies/list/wp.php
+++ b/tests/dependencies/list/wp.php
@@ -6,7 +6,9 @@
  */
 
 function wp_test_reset_options(): void {
-	$GLOBALS['wp_test_options'] = array( 'blog_charset' => 'UTF-8' );
+	$GLOBALS['wp_test_options']    = array( 'blog_charset' => 'UTF-8' );
+	$GLOBALS['wp_test_transients'] = array();
+	$GLOBALS['wp_test_redirects']  = array();
 }
 
 wp_test_reset_options();
@@ -40,6 +42,62 @@ function current_user_can( $capability ) {
 }
 
 function wp_verify_nonce( $nonce, $action = -1 ) {
+	return ! isset( $GLOBALS['wp_test_nonce_valid'] ) || $GLOBALS['wp_test_nonce_valid'];
+}
+
+function wp_create_nonce( $action = -1 ) {
+	return 'test-nonce';
+}
+
+function wp_nonce_url( $actionurl, $action = -1, $name = '_wpnonce' ) {
+	return add_query_arg( $name, wp_create_nonce( $action ), $actionurl );
+}
+
+function wp_generate_password( $length = 12, $special_chars = true, $extra_special_chars = false ) {
+	return str_repeat( 'a', $length );
+}
+
+function admin_url( $path = '' ) {
+	return 'https://example.com/wp-admin/' . $path;
+}
+
+function add_query_arg( $args, $url = '' ) {
+	$parts = explode( '?', $url, 2 );
+	$query = array();
+
+	if ( isset( $parts[1] ) ) {
+		wp_parse_str( $parts[1], $query );
+	}
+
+	$query = array_merge( $query, is_array( $args ) ? $args : array() );
+
+	return $parts[0] . '?' . http_build_query( $query );
+}
+
+/**
+ * Production code exits after redirecting, so the stub throws instead to let tests assert on the redirect.
+ */
+class WP_Redirect_Test_Exception extends Exception {}
+
+function wp_safe_redirect( $location, $status = 302 ) {
+	$GLOBALS['wp_test_redirects'][] = $location;
+
+	throw new WP_Redirect_Test_Exception( $location );
+}
+
+function set_transient( $transient, $value, $expiration = 0 ) {
+	$GLOBALS['wp_test_transients'][ $transient ] = $value;
+
+	return true;
+}
+
+function get_transient( $transient ) {
+	return array_key_exists( $transient, $GLOBALS['wp_test_transients'] ) ? $GLOBALS['wp_test_transients'][ $transient ] : false;
+}
+
+function delete_transient( $transient ) {
+	unset( $GLOBALS['wp_test_transients'][ $transient ] );
+
 	return true;
 }
 
@@ -57,6 +115,22 @@ function wp_schedule_event( $timestamp, $recurrence, $hook ) {
 
 if ( ! defined( 'DAY_IN_SECONDS' ) ) {
 	define( 'DAY_IN_SECONDS', 86400 );
+}
+
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+if ( ! defined( 'OMNISEND_CORE_SETTINGS_PAGE' ) ) {
+	define( 'OMNISEND_CORE_SETTINGS_PAGE', 'omnisend' );
+}
+
+if ( ! defined( 'OMNISEND_CORE_OAUTH_ISSUER' ) ) {
+	define( 'OMNISEND_CORE_OAUTH_ISSUER', 'https://app.omnisend.com' );
+}
+
+if ( ! defined( 'OMNISEND_CORE_OAUTH_CLIENT_NAME' ) ) {
+	define( 'OMNISEND_CORE_OAUTH_CLIENT_NAME', 'WordPress' );
 }
 
 if ( ! defined( 'OMNISEND_CORE_PLUGIN_VERSION' ) ) {


### PR DESCRIPTION
Initiated-by: zbignev@omnisend.com

## What

Makes the connect path dual-mode, stacked on the `/api` migration branch (PR #179).

- New `Internal\OAuthClient`: RFC 7591 dynamic client registration (`POST /oauth2/register`), authorize URL with `state` in a transient, code exchange and refresh at `POST /oauth2/token`, 60s expiry skew.
- `Internal\Options`: explicit auth mode (`api_key` / `oauth`) plus OAuth client credentials and tokens. Mode resolution keeps old installs working with no migration step:

```php
get_auth_mode() = stored mode ?: ( get_api_key() === '' ? '' : AUTH_MODE_API_KEY )
```

- `ApiRequest::authorization( $api_key )` is now the single place that resolves a credential: OAuth mode → `Bearer <access token>` (refreshing when near expiry, `WP_Error` if refresh fails — never an API-key fallback), otherwise `Omnisend-API-Key <key>`. `ApiRequest::headers()` takes a ready authorization header instead of an API key, so version/auth headers stay in one place.
- `Internal\Connection::handle_oauth_request()` (hooked on `admin_init`) handles `omnisend_oauth=connect|callback`: connect is `wp_nonce_url`-protected, the provider callback is verified with the OAuth `state` (the provider cannot echo a WP nonce back). It reads `GET /api/brands/current`, rejects non-WordPress brands, then writes platform data with `POST /api/brands/current` using the bearer token. The landing page's connect buttons now start this flow.
- OAuth failures call `Options::clear_oauth_tokens()` (not `disconnect()`), so an already API-key-connected store keeps its key and stays connected.
- `Client` resolves the authorization header once per instance and reports the resolution error from `check_setup()`; brand ID comes from the stored option in OAuth mode instead of being parsed out of the API key.

### Retained deprecated `/v3` account write — deliberate

PR #179 pointed the account writes at `/api`. That is wrong for API-key installs and is reverted here: a brand API key gets `403 accounts.write` on `POST /api/accounts`, `POST /api/accounts/{brandID}` is not registered upstream, and `POST /api/brands/current` is OAuth-only. So the account write stays on the deprecated endpoints for API-key installs only:

```php
// Internal\Connection (pasted API key, brand Omnisend has no platform for)
POST https://api.omnisend.com/v3/accounts            + X-API-Key
// Internal\V1\Client::connect_store()
api_key mode → POST OMNISEND_CORE_API_V3 . '/accounts/' . $brand_id  + X-API-Key
oauth  mode → POST OMNISEND_CORE_API . '/brands/current'             + Bearer
```

`ApiRequest::legacy_api_key_headers()` builds those unversioned `X-API-Key` headers. The brand **read** is `GET /api/brands/current` in both modes (verified working with an API key). **A `/v3` sunset date is therefore a deadline for API-key installs** — after it, they must be moved to OAuth.

Tests: `AuthModeTest` (legacy key stays api_key, client credentials alone don't migrate, bearer usage, refresh + rotation, no fallback on refresh failure, `connect_store` per mode), `OAuthConnectionTest` (registration, authorize params, code exchange, state mismatch, denial, non-WordPress brand, write failure cleanup), `ConnectionTest` (API-key connect via `/v3/accounts`, unverified response rejected).

## Why

Per the requester's decision superseding the original "no OAuth" non-goal: new connections and reconnects must use OAuth and use the OAuth credential for API calls, while already-connected API-key installs must keep working unchanged after a plugin update — which the `/api` account routes cannot support.

Open items raised on the issue, not assumed here: App Market client name / callback-domain whitelist for per-site admin URLs, plain-HTTP sites, PKCE, whether client secrets and refresh tokens in WP options are acceptable, and #187's guarantee that legacy API keys carry `brands.read`.

Fixes #188


Link to Devin session: https://app.devin.ai/sessions/b2e7d2496bbe435b8fd99a1e11bb1317
Requested by: @zbignev-omnisend